### PR TITLE
fix: use dynamic port for WebSocket connection

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -243,7 +243,8 @@ class WebSocketHandler {
     async connect() {
         try {
             this.client.log('Connecting via WebSocket...');
-            this.ws = new WebSocket('ws://localhost:3000');
+            const wsUrl = `ws://${window.location.hostname}:${window.location.port}`;
+            this.ws = new WebSocket(wsUrl);
             
             this.ws.onopen = () => {
                 this.client.isConnected = true;


### PR DESCRIPTION
Replace hardcoded localhost:3000 with dynamic port detection using window.location.hostname and window.location.port to support running the server on any port.

Fixes #1

Generated with [Claude Code](https://claude.ai/code)