### PR TITLE
docs: dependency PR policy and template for issue #14

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/dependency.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dependency.md
@@ -1,0 +1,17 @@
+## Dependency PR Checklist
+
+- [ ] Dependency-only change scope (versions/lockfile/metadata)
+- [ ] Required checks passed (`Dependabot Updates`, `CodeQL`)
+- [ ] Any failed advisory `Claude Code Review` result reviewed
+- [ ] Follow-up issue created if advisory automation failed
+
+## Merge Decision
+
+- **Required checks green:** merge allowed
+- **Advisory Claude failure only:** merge allowed + create follow-up issue
+- **Required check failure:** do not merge
+
+## Evidence
+
+- Required checks run URL:
+- Follow-up issue URL (if advisory failed):

--- a/docs/dependency-pr-policy.md
+++ b/docs/dependency-pr-policy.md
@@ -1,0 +1,33 @@
+# Dependency PR Merge Policy
+
+This policy keeps merge safety strict while treating flaky advisory automation as non-blocking.
+
+## Required merge gates
+
+A dependency PR can merge only when all required checks pass.
+
+- Dependabot Updates
+- CodeQL
+
+Do **not** mark `Claude Code Review` as required.
+
+## Advisory signal handling
+
+If `Claude Code Review` fails but all required checks are green:
+
+1. Merge is allowed.
+2. Open a follow-up issue labeled `ci` and `automation`.
+3. Link the follow-up issue in the merged PR comments.
+
+## 5-minute maintainer decision flow
+
+1. Confirm PR scope is dependency-only (versions, lockfile, generated metadata).
+2. Confirm required checks are green.
+3. If advisory Claude review failed, scan output for real high-risk findings.
+4. Merge when no high-risk findings block release.
+5. File follow-up issue for advisory workflow reliability if needed.
+
+## Evidence to attach in issue #14
+
+- Branch protection screenshot for `main` showing only required checks above.
+- Link to one merged dependency PR where this policy was applied.


### PR DESCRIPTION
## Summary
Implements the documentation/runtime policy pieces from issue #14 to unblock dependency PR merges when advisory Claude review is flaky.

### Included
- `docs/dependency-pr-policy.md` with required-vs-advisory merge policy and 5-minute maintainer decision flow
- `.github/PULL_REQUEST_TEMPLATE/dependency.md` with explicit dependency PR checklist and merge decision logic

## Why
Prevents dependency PR lane stalls caused by non-gating advisory workflow failures while preserving strict required checks.

Closes #14
