### PR TITLE
feat: test suite + tooling, secure crypto, centralized error handling, daily CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+#
+# Pre-commit quality gate for voice-agent-carnival.
+# Runs lint -> format check -> tests before allowing a commit.
+#
+# Enable once per clone:
+#   git config core.hooksPath .githooks
+# (or run `npm run prepare`)
+
+set -e
+
+echo "▶ pre-commit: eslint"
+npm run lint
+
+echo "▶ pre-commit: prettier --check"
+npm run format:check
+
+echo "▶ pre-commit: vitest"
+npm test
+
+echo "✓ pre-commit checks passed"

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -1,0 +1,43 @@
+name: Daily CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  quality-and-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint (ESLint)
+        run: npm run lint
+
+      - name: Format check (Prettier)
+        run: npm run format:check
+
+      - name: Run tests (Vitest)
+        run: npm test
+
+      - name: Syntax check entrypoint
+        run: node --check src/core/server.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+node_modules/
+public/
+data/
+dist/
+build/
+package-lock.json
+docs/
+features/
+quality/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+    "semi": true,
+    "singleQuote": true,
+    "tabWidth": 4,
+    "printWidth": 100,
+    "trailingComma": "none",
+    "arrowParens": "always",
+    "endOfLine": "lf"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,45 @@
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default [
+    js.configs.recommended,
+    {
+        files: ['**/*.js'],
+        languageOptions: {
+            ecmaVersion: 2023,
+            sourceType: 'module',
+            globals: {
+                ...globals.node,
+                ...globals.browser
+            }
+        },
+        rules: {
+            'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+            'no-console': 'off',
+            'prefer-const': 'warn',
+            eqeqeq: ['warn', 'smart'],
+            'no-var': 'error'
+        }
+    },
+    {
+        files: ['test/**/*.js'],
+        languageOptions: {
+            globals: {
+                ...globals.node
+            }
+        }
+    },
+    {
+        ignores: [
+            'node_modules/**',
+            'public/**',
+            'data/**',
+            'dist/**',
+            'build/**',
+            'docs/**',
+            'features/**',
+            'quality/**',
+            'scripts/**'
+        ]
+    }
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,13 @@
         "ws": "^8.18.0"
       },
       "devDependencies": {
-        "@types/node": "^20.11.24"
+        "@eslint/js": "^9.13.0",
+        "@types/node": "^20.11.24",
+        "eslint": "^9.13.0",
+        "globals": "^15.11.0",
+        "prettier": "^3.3.3",
+        "supertest": "^7.0.0",
+        "vitest": "^2.1.4"
       }
     },
     "node_modules/@elevenlabs/elevenlabs-js": {
@@ -32,6 +38,1103 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
@@ -40,6 +1143,119 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -55,10 +1271,104 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -114,6 +1424,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -121,6 +1442,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -152,10 +1483,114 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
       "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "license": "MIT"
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -194,6 +1629,13 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -207,6 +1649,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -214,6 +1671,33 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -233,6 +1717,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -294,6 +1789,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -306,11 +1808,268 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -319,6 +2078,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -382,6 +2151,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -400,6 +2210,79 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -416,6 +2299,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -464,6 +2362,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -476,11 +2400,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -528,6 +2478,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -541,6 +2528,144 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -612,10 +2737,49 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -680,6 +2844,79 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -689,11 +2926,110 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -706,6 +3042,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -774,6 +3120,61 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -862,6 +3263,29 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -934,6 +3358,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -941,6 +3389,167 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -957,6 +3566,19 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -987,6 +3609,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1005,6 +3637,205 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -1020,6 +3851,56 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.3",
@@ -1040,6 +3921,19 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,34 +1,47 @@
 {
-  "name": "voice-echo-agent",
-  "version": "1.0.0",
-  "description": "A voice agent that echoes what you say using OpenAI Realtime API",
-  "main": "src/core/server.js",
-  "type": "module",
-  "scripts": {
-    "start": "node src/core/server.js",
-    "dev": "node --watch src/core/server.js",
-    "setup": "npm install && cp .env.example .env",
-    "validate": "node scripts/validate.js",
-    "test": "node --check src/core/server.js && echo 'Syntax check passed'"
-  },
-  "dependencies": {
-    "@elevenlabs/elevenlabs-js": "^2.14.0",
-    "cors": "^2.8.5",
-    "dotenv": "^16.4.5",
-    "express": "^4.22.1",
-    "ws": "^8.18.0"
-  },
-  "devDependencies": {
-    "@types/node": "^20.11.24"
-  },
-  "keywords": [
-    "voice",
-    "ai",
-    "openai",
-    "realtime",
-    "echo",
-    "websocket"
-  ],
-  "author": "",
-  "license": "MIT"
+    "name": "voice-echo-agent",
+    "version": "1.0.0",
+    "description": "A voice agent that echoes what you say using OpenAI Realtime API",
+    "main": "src/core/server.js",
+    "type": "module",
+    "scripts": {
+        "start": "node src/core/server.js",
+        "dev": "node --watch src/core/server.js",
+        "setup": "npm install && cp .env.example .env",
+        "validate": "node scripts/validate.js",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
+        "format": "prettier --write \"src/**/*.js\" \"test/**/*.js\" \"*.{js,json}\"",
+        "format:check": "prettier --check \"src/**/*.js\" \"test/**/*.js\" \"*.{js,json}\"",
+        "precommit": "npm run lint && npm run format:check && npm test",
+        "prepare": "git config core.hooksPath .githooks || true"
+    },
+    "dependencies": {
+        "@elevenlabs/elevenlabs-js": "^2.14.0",
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
+        "express": "^4.22.1",
+        "ws": "^8.18.0"
+    },
+    "devDependencies": {
+        "@eslint/js": "^9.13.0",
+        "@types/node": "^20.11.24",
+        "eslint": "^9.13.0",
+        "globals": "^15.11.0",
+        "prettier": "^3.3.3",
+        "supertest": "^7.0.0",
+        "vitest": "^2.1.4"
+    },
+    "keywords": [
+        "voice",
+        "ai",
+        "openai",
+        "realtime",
+        "echo",
+        "websocket"
+    ],
+    "author": "",
+    "license": "MIT"
 }

--- a/src/config/config-manager.js
+++ b/src/config/config-manager.js
@@ -54,7 +54,7 @@ export class ConfigManager {
         }
 
         const userConfig = this.configs.get(userId);
-        
+
         // Encrypt sensitive data
         const encryptedConfig = {
             ...config,
@@ -64,7 +64,7 @@ export class ConfigManager {
 
         userConfig.providers[provider] = encryptedConfig;
         userConfig.lastUsed = new Date().toISOString();
-        
+
         this.configs.set(userId, userConfig);
         await this.saveConfigurations();
 
@@ -83,7 +83,7 @@ export class ConfigManager {
         }
 
         const config = userConfig.providers[provider];
-        
+
         // Decrypt sensitive data
         if (config.encrypted && config.apiKey) {
             return {
@@ -106,7 +106,7 @@ export class ConfigManager {
             return [];
         }
 
-        return Object.keys(userConfig.providers).map(provider => ({
+        return Object.keys(userConfig.providers).map((provider) => ({
             provider,
             configured: true,
             lastUsed: userConfig.lastUsed,
@@ -132,7 +132,7 @@ export class ConfigManager {
         const userConfig = this.configs.get(userId);
         userConfig.settings = { ...userConfig.settings, ...settings };
         userConfig.lastUsed = new Date().toISOString();
-        
+
         this.configs.set(userId, userConfig);
         await this.saveConfigurations();
 
@@ -161,7 +161,7 @@ export class ConfigManager {
 
         delete userConfig.providers[provider];
         userConfig.lastUsed = new Date().toISOString();
-        
+
         this.configs.set(userId, userConfig);
         await this.saveConfigurations();
 
@@ -194,7 +194,7 @@ export class ConfigManager {
             const providers = Object.keys(config.providers);
             stats.totalProviders += providers.length;
 
-            providers.forEach(provider => {
+            providers.forEach((provider) => {
                 stats.providerUsage[provider] = (stats.providerUsage[provider] || 0) + 1;
             });
 
@@ -218,10 +218,10 @@ export class ConfigManager {
         try {
             const data = await fs.readFile(this.configFile, 'utf8');
             const parsedData = JSON.parse(data);
-            
+
             // Convert plain object back to Map
             this.configs = new Map(Object.entries(parsedData.configs || {}));
-            
+
             console.log(`📂 Loaded ${this.configs.size} user configurations`);
         } catch (error) {
             if (error.code !== 'ENOENT') {
@@ -251,38 +251,62 @@ export class ConfigManager {
     }
 
     /**
-     * Encrypt sensitive data
+     * Derive a 32-byte AES-256 key from the configured encryption key.
+     * Uses scrypt with a fixed salt so the same key/passphrase always
+     * derives the same cipher key (required for round-trip decryption).
+     */
+    deriveKey() {
+        // Fixed, deterministic salt. The secret strength comes from
+        // this.encryptionKey; per-message uniqueness comes from the random IV.
+        const salt = 'voice-router-config-salt';
+        return crypto.scryptSync(this.encryptionKey, salt, 32);
+    }
+
+    /**
+     * Encrypt sensitive data.
+     * Uses AES-256-CBC via createCipheriv with a scrypt-derived key and a
+     * random per-message IV. The IV is stored alongside the ciphertext in
+     * the `iv:ciphertext` (hex) on-disk format.
      */
     encrypt(text) {
         if (!text) return null;
-        
+
+        const key = this.deriveKey();
         const iv = crypto.randomBytes(16);
-        const cipher = crypto.createCipher('aes-256-cbc', this.encryptionKey);
-        
+        const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+
         let encrypted = cipher.update(text, 'utf8', 'hex');
         encrypted += cipher.final('hex');
-        
+
         return iv.toString('hex') + ':' + encrypted;
     }
 
     /**
-     * Decrypt sensitive data
+     * Decrypt sensitive data.
+     * Parses the stored IV from the `iv:ciphertext` format and uses
+     * createDecipheriv with the same scrypt-derived key. Input that is not
+     * in the expected encrypted format is returned unchanged (existing
+     * contract used to detect plaintext/legacy values).
      */
     decrypt(encryptedText) {
         if (!encryptedText) return null;
-        
+
         try {
             const parts = encryptedText.split(':');
             if (parts.length !== 2) return encryptedText; // Not encrypted
-            
+
             const iv = Buffer.from(parts[0], 'hex');
             const encrypted = parts[1];
-            
-            const decipher = crypto.createDecipher('aes-256-cbc', this.encryptionKey);
-            
+
+            // A valid IV is 16 bytes (32 hex chars); bail to raw value otherwise.
+            if (iv.length !== 16) return encryptedText;
+
+            const key = this.deriveKey();
+            const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+
             let decrypted = decipher.update(encrypted, 'hex', 'utf8');
             decrypted += decipher.final('utf8');
-            
+
             return decrypted;
         } catch (error) {
             console.error('❌ Decryption failed:', error);
@@ -295,7 +319,9 @@ export class ConfigManager {
      */
     generateKey() {
         const key = crypto.randomBytes(32).toString('hex');
-        console.log('🔑 Generated new encryption key. Set CONFIG_ENCRYPTION_KEY in .env for persistence.');
+        console.log(
+            '🔑 Generated new encryption key. Set CONFIG_ENCRYPTION_KEY in .env for persistence.'
+        );
         return key;
     }
 
@@ -305,11 +331,11 @@ export class ConfigManager {
     validateProviderConfig(provider, config) {
         const requiredFields = ['apiKey'];
         const optionalFields = ['model', 'voice', 'language', 'options'];
-        
+
         const errors = [];
-        
+
         // Check required fields
-        requiredFields.forEach(field => {
+        requiredFields.forEach((field) => {
             if (!config[field]) {
                 errors.push(`Missing required field: ${field}`);
             }

--- a/src/config/voice-providers-config.js
+++ b/src/config/voice-providers-config.js
@@ -4,274 +4,304 @@
  */
 
 export const VOICE_PROVIDERS = {
-  // Real-time Speech-to-Speech Providers
-  'openai-realtime': {
-    name: 'OpenAI Realtime API',
-    type: 'realtime',
-    capabilities: ['speech-to-speech', 'real-time', 'function-calling'],
-    latency: '~500ms',
-    pricing: '$0.06/min input, $0.24/min output',
-    models: ['gpt-4o-realtime-preview-2024-12-17'],
-    auth: 'bearer',
-    endpoint: 'wss://api.openai.com/v1/realtime',
-    features: {
-      streaming: true,
-      interruption: true,
-      emotions: false,
-      customVoices: false,
-      languages: ['en']
-    }
-  },
+    // Real-time Speech-to-Speech Providers
+    'openai-realtime': {
+        name: 'OpenAI Realtime API',
+        type: 'realtime',
+        capabilities: ['speech-to-speech', 'real-time', 'function-calling'],
+        latency: '~500ms',
+        pricing: '$0.06/min input, $0.24/min output',
+        models: ['gpt-4o-realtime-preview-2024-12-17'],
+        auth: 'bearer',
+        endpoint: 'wss://api.openai.com/v1/realtime',
+        features: {
+            streaming: true,
+            interruption: true,
+            emotions: false,
+            customVoices: false,
+            languages: ['en']
+        }
+    },
 
-  // Speech-to-Text Providers
-  'deepgram': {
-    name: 'Deepgram Nova-3',
-    type: 'stt',
-    capabilities: ['speech-to-text', 'real-time', 'pre-recorded'],
-    latency: '<300ms',
-    pricing: '$0.0043/min pre-recorded, $0.0077/min streaming',
-    models: ['nova-3', 'nova-2', 'whisper'],
-    auth: 'token',
-    endpoint: 'wss://api.deepgram.com/v1/listen',
-    features: {
-      streaming: true,
-      punctuation: true,
-      profanityFilter: true,
-      languageDetection: true,
-      languages: ['en', 'es', 'fr', 'de', 'it', 'pt', 'nl', 'hi', 'ja', 'ko', 'zh', 'ru', 'ar']
-    }
-  },
+    // Speech-to-Text Providers
+    deepgram: {
+        name: 'Deepgram Nova-3',
+        type: 'stt',
+        capabilities: ['speech-to-text', 'real-time', 'pre-recorded'],
+        latency: '<300ms',
+        pricing: '$0.0043/min pre-recorded, $0.0077/min streaming',
+        models: ['nova-3', 'nova-2', 'whisper'],
+        auth: 'token',
+        endpoint: 'wss://api.deepgram.com/v1/listen',
+        features: {
+            streaming: true,
+            punctuation: true,
+            profanityFilter: true,
+            languageDetection: true,
+            languages: [
+                'en',
+                'es',
+                'fr',
+                'de',
+                'it',
+                'pt',
+                'nl',
+                'hi',
+                'ja',
+                'ko',
+                'zh',
+                'ru',
+                'ar'
+            ]
+        }
+    },
 
-  'assemblyai': {
-    name: 'AssemblyAI Universal-2',
-    type: 'stt',
-    capabilities: ['speech-to-text', 'real-time', 'pre-recorded'],
-    latency: '~400ms',
-    pricing: '$0.37/hour async, $0.47/hour real-time',
-    models: ['universal-2', 'universal-1'],
-    auth: 'token',
-    endpoint: 'wss://api.assemblyai.com/v2/realtime/ws',
-    features: {
-      streaming: true,
-      speakerLabels: true,
-      sentimentAnalysis: true,
-      topicDetection: true,
-      languages: ['en']
-    }
-  },
+    assemblyai: {
+        name: 'AssemblyAI Universal-2',
+        type: 'stt',
+        capabilities: ['speech-to-text', 'real-time', 'pre-recorded'],
+        latency: '~400ms',
+        pricing: '$0.37/hour async, $0.47/hour real-time',
+        models: ['universal-2', 'universal-1'],
+        auth: 'token',
+        endpoint: 'wss://api.assemblyai.com/v2/realtime/ws',
+        features: {
+            streaming: true,
+            speakerLabels: true,
+            sentimentAnalysis: true,
+            topicDetection: true,
+            languages: ['en']
+        }
+    },
 
-  'whisper': {
-    name: 'OpenAI Whisper',
-    type: 'stt',
-    capabilities: ['speech-to-text', 'pre-recorded'],
-    latency: '~1-3s',
-    pricing: '$0.006/minute',
-    models: ['whisper-1'],
-    auth: 'bearer',
-    endpoint: 'https://api.openai.com/v1/audio/transcriptions',
-    features: {
-      streaming: false,
-      translation: true,
-      timestamped: true,
-      languages: ['en', 'es', 'fr', 'de', 'it', 'pt', 'nl', 'hi', 'ja', 'ko', 'zh', 'ru', 'ar', 'many_more']
-    }
-  },
+    whisper: {
+        name: 'OpenAI Whisper',
+        type: 'stt',
+        capabilities: ['speech-to-text', 'pre-recorded'],
+        latency: '~1-3s',
+        pricing: '$0.006/minute',
+        models: ['whisper-1'],
+        auth: 'bearer',
+        endpoint: 'https://api.openai.com/v1/audio/transcriptions',
+        features: {
+            streaming: false,
+            translation: true,
+            timestamped: true,
+            languages: [
+                'en',
+                'es',
+                'fr',
+                'de',
+                'it',
+                'pt',
+                'nl',
+                'hi',
+                'ja',
+                'ko',
+                'zh',
+                'ru',
+                'ar',
+                'many_more'
+            ]
+        }
+    },
 
-  'google-stt': {
-    name: 'Google Cloud Speech-to-Text',
-    type: 'stt',
-    capabilities: ['speech-to-text', 'real-time', 'pre-recorded'],
-    latency: '~500ms',
-    pricing: 'Variable by region and usage',
-    models: ['latest', 'command_and_search', 'phone_call', 'video'],
-    auth: 'service-account',
-    endpoint: 'wss://speech.googleapis.com/v1/speech:streamingrecognize',
-    features: {
-      streaming: true,
-      adaptation: true,
-      profanityFilter: true,
-      languageDetection: true,
-      languages: ['125+ languages and variants']
-    }
-  },
+    'google-stt': {
+        name: 'Google Cloud Speech-to-Text',
+        type: 'stt',
+        capabilities: ['speech-to-text', 'real-time', 'pre-recorded'],
+        latency: '~500ms',
+        pricing: 'Variable by region and usage',
+        models: ['latest', 'command_and_search', 'phone_call', 'video'],
+        auth: 'service-account',
+        endpoint: 'wss://speech.googleapis.com/v1/speech:streamingrecognize',
+        features: {
+            streaming: true,
+            adaptation: true,
+            profanityFilter: true,
+            languageDetection: true,
+            languages: ['125+ languages and variants']
+        }
+    },
 
-  'azure-stt': {
-    name: 'Microsoft Azure Speech Services',
-    type: 'stt',
-    capabilities: ['speech-to-text', 'real-time', 'pre-recorded'],
-    latency: '~400ms',
-    pricing: 'Variable by region and usage',
-    models: ['unified', 'conversation', 'dictation'],
-    auth: 'subscription-key',
-    endpoint: 'wss://{{region}}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1',
-    features: {
-      streaming: true,
-      customModels: true,
-      profanityFilter: true,
-      translation: true,
-      languages: ['100+ languages']
-    }
-  },
+    'azure-stt': {
+        name: 'Microsoft Azure Speech Services',
+        type: 'stt',
+        capabilities: ['speech-to-text', 'real-time', 'pre-recorded'],
+        latency: '~400ms',
+        pricing: 'Variable by region and usage',
+        models: ['unified', 'conversation', 'dictation'],
+        auth: 'subscription-key',
+        endpoint:
+            'wss://{{region}}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1',
+        features: {
+            streaming: true,
+            customModels: true,
+            profanityFilter: true,
+            translation: true,
+            languages: ['100+ languages']
+        }
+    },
 
-  // Text-to-Speech Providers
-  'elevenlabs': {
-    name: 'ElevenLabs TTS',
-    type: 'tts',
-    capabilities: ['text-to-speech', 'voice-cloning', 'real-time'],
-    latency: '<300ms with Turbo',
-    pricing: '$0.30/1k chars (Creator), $0.24/1k chars (Pro)',
-    models: ['multilingual-v2', 'turbo-v2', 'eleven_english_v1'],
-    auth: 'xi-api-key',
-    endpoint: 'https://api.elevenlabs.io/v1/text-to-speech',
-    features: {
-      streaming: true,
-      voiceCloning: true,
-      emotions: true,
-      customVoices: true,
-      languages: ['142 languages and accents']
-    }
-  },
+    // Text-to-Speech Providers
+    elevenlabs: {
+        name: 'ElevenLabs TTS',
+        type: 'tts',
+        capabilities: ['text-to-speech', 'voice-cloning', 'real-time'],
+        latency: '<300ms with Turbo',
+        pricing: '$0.30/1k chars (Creator), $0.24/1k chars (Pro)',
+        models: ['multilingual-v2', 'turbo-v2', 'eleven_english_v1'],
+        auth: 'xi-api-key',
+        endpoint: 'https://api.elevenlabs.io/v1/text-to-speech',
+        features: {
+            streaming: true,
+            voiceCloning: true,
+            emotions: true,
+            customVoices: true,
+            languages: ['142 languages and accents']
+        }
+    },
 
-  'playht': {
-    name: 'PlayHT',
-    type: 'tts',
-    capabilities: ['text-to-speech', 'real-time', 'voice-cloning'],
-    latency: '<300ms',
-    pricing: 'Usage-based pricing',
-    models: ['PlayHT2.0-turbo', 'PlayHT2.0', 'PlayHT1.0'],
-    auth: 'x-api-key',
-    endpoint: 'https://api.play.ht/api/v2/tts',
-    features: {
-      streaming: true,
-      voiceCloning: true,
-      emotions: true,
-      customVoices: true,
-      languages: ['142 languages']
-    }
-  },
+    playht: {
+        name: 'PlayHT',
+        type: 'tts',
+        capabilities: ['text-to-speech', 'real-time', 'voice-cloning'],
+        latency: '<300ms',
+        pricing: 'Usage-based pricing',
+        models: ['PlayHT2.0-turbo', 'PlayHT2.0', 'PlayHT1.0'],
+        auth: 'x-api-key',
+        endpoint: 'https://api.play.ht/api/v2/tts',
+        features: {
+            streaming: true,
+            voiceCloning: true,
+            emotions: true,
+            customVoices: true,
+            languages: ['142 languages']
+        }
+    },
 
-  'google-tts': {
-    name: 'Google Cloud Text-to-Speech',
-    type: 'tts',
-    capabilities: ['text-to-speech', 'neural-voices'],
-    latency: '~500ms',
-    pricing: 'Variable by voice type',
-    models: ['standard', 'wavenet', 'neural2', 'polyglot'],
-    auth: 'service-account',
-    endpoint: 'https://texttospeech.googleapis.com/v1/text:synthesize',
-    features: {
-      streaming: false,
-      customVoices: true,
-      ssml: true,
-      audioProfiles: true,
-      languages: ['220+ voices in 40+ languages']
-    }
-  },
+    'google-tts': {
+        name: 'Google Cloud Text-to-Speech',
+        type: 'tts',
+        capabilities: ['text-to-speech', 'neural-voices'],
+        latency: '~500ms',
+        pricing: 'Variable by voice type',
+        models: ['standard', 'wavenet', 'neural2', 'polyglot'],
+        auth: 'service-account',
+        endpoint: 'https://texttospeech.googleapis.com/v1/text:synthesize',
+        features: {
+            streaming: false,
+            customVoices: true,
+            ssml: true,
+            audioProfiles: true,
+            languages: ['220+ voices in 40+ languages']
+        }
+    },
 
-  'azure-tts': {
-    name: 'Microsoft Azure Text-to-Speech',
-    type: 'tts',
-    capabilities: ['text-to-speech', 'neural-voices', 'custom-voices'],
-    latency: '~400ms',
-    pricing: 'Variable by voice type',
-    models: ['neural', 'standard'],
-    auth: 'subscription-key',
-    endpoint: 'https://{{region}}.tts.speech.microsoft.com/cognitiveservices/v1',
-    features: {
-      streaming: true,
-      customVoices: true,
-      ssml: true,
-      emotions: true,
-      languages: ['400+ voices in 140+ languages']
-    }
-  },
+    'azure-tts': {
+        name: 'Microsoft Azure Text-to-Speech',
+        type: 'tts',
+        capabilities: ['text-to-speech', 'neural-voices', 'custom-voices'],
+        latency: '~400ms',
+        pricing: 'Variable by voice type',
+        models: ['neural', 'standard'],
+        auth: 'subscription-key',
+        endpoint: 'https://{{region}}.tts.speech.microsoft.com/cognitiveservices/v1',
+        features: {
+            streaming: true,
+            customVoices: true,
+            ssml: true,
+            emotions: true,
+            languages: ['400+ voices in 140+ languages']
+        }
+    },
 
-  'amazon-polly': {
-    name: 'Amazon Polly',
-    type: 'tts',
-    capabilities: ['text-to-speech', 'neural-voices'],
-    latency: '~600ms',
-    pricing: '$4.00 per 1M characters (Neural)',
-    models: ['standard', 'neural', 'long-form'],
-    auth: 'aws-signature',
-    endpoint: 'https://polly.{{region}}.amazonaws.com/v1/speech',
-    features: {
-      streaming: true,
-      lexicons: true,
-      ssml: true,
-      speechmarks: true,
-      languages: ['60+ voices in 30+ languages']
-    }
-  },
+    'amazon-polly': {
+        name: 'Amazon Polly',
+        type: 'tts',
+        capabilities: ['text-to-speech', 'neural-voices'],
+        latency: '~600ms',
+        pricing: '$4.00 per 1M characters (Neural)',
+        models: ['standard', 'neural', 'long-form'],
+        auth: 'aws-signature',
+        endpoint: 'https://polly.{{region}}.amazonaws.com/v1/speech',
+        features: {
+            streaming: true,
+            lexicons: true,
+            ssml: true,
+            speechmarks: true,
+            languages: ['60+ voices in 30+ languages']
+        }
+    },
 
-  'murf': {
-    name: 'Murf AI',
-    type: 'tts',
-    capabilities: ['text-to-speech', 'voice-customization'],
-    latency: '~800ms',
-    pricing: 'Subscription-based',
-    models: ['murf-ai'],
-    auth: 'api-key',
-    endpoint: 'https://api.murf.ai/v1/speech/generate',
-    features: {
-      streaming: false,
-      customization: true,
-      emotions: true,
-      brandVoices: true,
-      languages: ['120+ voices in 20+ languages']
-    }
-  },
+    murf: {
+        name: 'Murf AI',
+        type: 'tts',
+        capabilities: ['text-to-speech', 'voice-customization'],
+        latency: '~800ms',
+        pricing: 'Subscription-based',
+        models: ['murf-ai'],
+        auth: 'api-key',
+        endpoint: 'https://api.murf.ai/v1/speech/generate',
+        features: {
+            streaming: false,
+            customization: true,
+            emotions: true,
+            brandVoices: true,
+            languages: ['120+ voices in 20+ languages']
+        }
+    },
 
-  // Hybrid/Conversational AI Providers
-  'elevenlabs-conversational': {
-    name: 'ElevenLabs Conversational AI',
-    type: 'conversational',
-    capabilities: ['speech-to-speech', 'conversation', 'interruption'],
-    latency: '<800ms',
-    pricing: 'Per-minute conversation pricing',
-    models: ['conversational-v1'],
-    auth: 'xi-api-key',
-    endpoint: 'wss://api.elevenlabs.io/v1/convai/conversation',
-    features: {
-      streaming: true,
-      interruption: true,
-      emotions: true,
-      customVoices: true,
-      languages: ['Multiple languages']
-    }
-  },
+    // Hybrid/Conversational AI Providers
+    'elevenlabs-conversational': {
+        name: 'ElevenLabs Conversational AI',
+        type: 'conversational',
+        capabilities: ['speech-to-speech', 'conversation', 'interruption'],
+        latency: '<800ms',
+        pricing: 'Per-minute conversation pricing',
+        models: ['conversational-v1'],
+        auth: 'xi-api-key',
+        endpoint: 'wss://api.elevenlabs.io/v1/convai/conversation',
+        features: {
+            streaming: true,
+            interruption: true,
+            emotions: true,
+            customVoices: true,
+            languages: ['Multiple languages']
+        }
+    },
 
-  // Cloud Providers with Comprehensive Services
-  'ibm-watson': {
-    name: 'IBM Watson Speech',
-    type: 'hybrid',
-    capabilities: ['speech-to-text', 'text-to-speech', 'custom-models'],
-    latency: '~500ms',
-    pricing: 'Usage-based',
-    models: ['watson-stt', 'watson-tts'],
-    auth: 'iam-token',
-    endpoint: 'https://api.us-south.speech-to-text.watson.cloud.ibm.com',
-    features: {
-      streaming: true,
-      customModels: true,
-      domainAdaptation: true,
-      speakerLabels: true,
-      languages: ['Multiple languages with domain specialization']
+    // Cloud Providers with Comprehensive Services
+    'ibm-watson': {
+        name: 'IBM Watson Speech',
+        type: 'hybrid',
+        capabilities: ['speech-to-text', 'text-to-speech', 'custom-models'],
+        latency: '~500ms',
+        pricing: 'Usage-based',
+        models: ['watson-stt', 'watson-tts'],
+        auth: 'iam-token',
+        endpoint: 'https://api.us-south.speech-to-text.watson.cloud.ibm.com',
+        features: {
+            streaming: true,
+            customModels: true,
+            domainAdaptation: true,
+            speakerLabels: true,
+            languages: ['Multiple languages with domain specialization']
+        }
     }
-  }
 };
 
 export const PROVIDER_CATEGORIES = {
-  'Real-time Speech-to-Speech': ['openai-realtime', 'elevenlabs-conversational'],
-  'Speech-to-Text': ['deepgram', 'assemblyai', 'whisper', 'google-stt', 'azure-stt'],
-  'Text-to-Speech': ['elevenlabs', 'playht', 'google-tts', 'azure-tts', 'amazon-polly', 'murf'],
-  'Enterprise/Hybrid': ['ibm-watson', 'azure-stt', 'google-stt']
+    'Real-time Speech-to-Speech': ['openai-realtime', 'elevenlabs-conversational'],
+    'Speech-to-Text': ['deepgram', 'assemblyai', 'whisper', 'google-stt', 'azure-stt'],
+    'Text-to-Speech': ['elevenlabs', 'playht', 'google-tts', 'azure-tts', 'amazon-polly', 'murf'],
+    'Enterprise/Hybrid': ['ibm-watson', 'azure-stt', 'google-stt']
 };
 
 export const PRICING_MODELS = {
-  'per-minute': ['openai-realtime', 'deepgram', 'whisper'],
-  'per-hour': ['assemblyai'],
-  'per-character': ['elevenlabs', 'playht', 'amazon-polly'],
-  'subscription': ['murf'],
-  'usage-based': ['google-stt', 'google-tts', 'azure-stt', 'azure-tts', 'ibm-watson']
+    'per-minute': ['openai-realtime', 'deepgram', 'whisper'],
+    'per-hour': ['assemblyai'],
+    'per-character': ['elevenlabs', 'playht', 'amazon-polly'],
+    subscription: ['murf'],
+    'usage-based': ['google-stt', 'google-tts', 'azure-stt', 'azure-tts', 'ibm-watson']
 };

--- a/src/core/server.js
+++ b/src/core/server.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
 import { VoiceAPIEndpoints } from '../routes/voice-api-endpoints.js';
+import { notFoundHandler, errorHandler } from '../middleware/error-middleware.js';
 
 // Load environment variables
 dotenv.config();
@@ -19,16 +20,18 @@ class MultiModalVoiceServer {
         this.app = express();
         this.server = createServer(this.app);
         this.wss = new WebSocketServer({ server: this.server });
-        
+
         this.setupExpress();
         this.setupWebSocket();
-        
+
         const port = process.env.PORT || 3000;
         this.server.listen(port, () => {
             console.log(`🎤 Multi-Modal Voice Agent Server running on http://localhost:${port}`);
             console.log(`📡 Supporting: WebSocket | WebRTC | SIP connections`);
             console.log(`🌐 Original Voice Agent: http://localhost:${port}`);
-            console.log(`🚀 Voice API Router (Open Router Style): http://localhost:${port}/voice-router`);
+            console.log(
+                `🚀 Voice API Router (Open Router Style): http://localhost:${port}/voice-router`
+            );
             console.log(`📊 API Documentation:`);
             console.log(`   - Models: http://localhost:${port}/v1/voice/models`);
             console.log(`   - Providers: http://localhost:${port}/v1/voice/providers`);
@@ -38,15 +41,15 @@ class MultiModalVoiceServer {
             console.log(`   - Usage: http://localhost:${port}/v1/voice/usage`);
         });
     }
-    
+
     setupExpress() {
         this.app.use(cors());
         this.app.use(express.json());
         this.app.use(express.static(path.join(__dirname, '../../public')));
-        
+
         this.app.get('/health', (req, res) => {
-            res.json({ 
-                status: 'healthy', 
+            res.json({
+                status: 'healthy',
                 timestamp: new Date().toISOString(),
                 api: 'OpenAI Realtime API (Direct)',
                 connections: ['WebSocket', 'WebRTC', 'SIP']
@@ -66,8 +69,8 @@ class MultiModalVoiceServer {
                 const response = await fetch('https://api.openai.com/v1/realtime/sessions', {
                     method: 'POST',
                     headers: {
-                        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
-                        'Content-Type': 'application/json',
+                        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+                        'Content-Type': 'application/json'
                     },
                     body: JSON.stringify({
                         model: 'gpt-4o-realtime-preview-2024-12-17',
@@ -84,13 +87,13 @@ class MultiModalVoiceServer {
                 }
 
                 const session = await response.json();
-                
+
                 // Check if response has the expected structure
                 if (!session.client_secret || !session.client_secret.value) {
                     throw new Error('Invalid session response: missing client_secret');
                 }
-                
-                res.json({ 
+
+                res.json({
                     token: session.client_secret.value,
                     expires_at: session.client_secret.expires_at,
                     session_id: session.id
@@ -141,13 +144,13 @@ class MultiModalVoiceServer {
                 });
 
                 const voicesResponse = await elevenlabs.voices.getAll();
-                
+
                 // Map voiceId to voice_id for client compatibility
-                const mappedVoices = (voicesResponse.voices || []).map(voice => ({
+                const mappedVoices = (voicesResponse.voices || []).map((voice) => ({
                     ...voice,
                     voice_id: voice.voiceId
                 }));
-                
+
                 res.json({
                     voices: mappedVoices,
                     provider: 'elevenlabs'
@@ -190,13 +193,13 @@ class MultiModalVoiceServer {
                 // Convert stream to buffer
                 const chunks = [];
                 const reader = audio.getReader();
-                
+
                 while (true) {
                     const { done, value } = await reader.read();
                     if (done) break;
                     chunks.push(value);
                 }
-                
+
                 const audioBuffer = Buffer.concat(chunks);
 
                 res.setHeader('Content-Type', 'audio/mpeg');
@@ -216,32 +219,40 @@ class MultiModalVoiceServer {
         this.app.get('/voice-router', (req, res) => {
             res.sendFile(path.join(__dirname, 'public', 'voice-router-ui.html'));
         });
+
+        // Centralized 404 + error handling. Registered after all routes so
+        // unknown /v1/voice/* paths return a JSON envelope instead of HTML,
+        // and all thrown errors are normalized with credentials redacted.
+        this.app.use(notFoundHandler);
+        this.app.use(errorHandler);
     }
-    
+
     setupWebSocket() {
         this.wss.on('connection', (clientWs, request) => {
             console.log('🔌 WebSocket client connected from:', request.socket.remoteAddress);
-            
+
             const sessionHandler = new WebSocketSessionHandler(clientWs);
-            
+
             clientWs.on('message', (message) => {
                 try {
                     const data = JSON.parse(message);
                     sessionHandler.handleClientMessage(data);
                 } catch (error) {
                     console.error('❌ Failed to parse client message:', error);
-                    clientWs.send(JSON.stringify({
-                        type: 'error',
-                        message: 'Invalid message format'
-                    }));
+                    clientWs.send(
+                        JSON.stringify({
+                            type: 'error',
+                            message: 'Invalid message format'
+                        })
+                    );
                 }
             });
-            
+
             clientWs.on('close', () => {
                 console.log('🔌 WebSocket client disconnected');
                 sessionHandler.cleanup();
             });
-            
+
             clientWs.on('error', (error) => {
                 console.error('❌ WebSocket client error:', error);
                 sessionHandler.cleanup();
@@ -256,10 +267,10 @@ class WebSocketSessionHandler {
         this.openaiWs = null;
         this.isConnectedToOpenAI = false;
         this.audioBuffer = [];
-        
+
         this.connectToOpenAI();
     }
-    
+
     async connectToOpenAI() {
         if (!process.env.OPENAI_API_KEY) {
             this.sendToClient({
@@ -268,23 +279,23 @@ class WebSocketSessionHandler {
             });
             return;
         }
-        
+
         try {
             console.log('🔗 Connecting to OpenAI Realtime API via WebSocket...');
-            
+
             const url = `wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview-2024-12-17`;
-            
+
             this.openaiWs = new WebSocket(url, {
                 headers: {
-                    'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+                    Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
                     'OpenAI-Beta': 'realtime=v1'
                 }
             });
-            
+
             this.openaiWs.on('open', () => {
                 console.log('✅ Connected to OpenAI Realtime API via WebSocket');
                 this.isConnectedToOpenAI = true;
-                
+
                 // Configure the session for echo functionality
                 this.sendToOpenAI({
                     type: 'session.update',
@@ -307,14 +318,14 @@ class WebSocketSessionHandler {
                         max_response_output_tokens: 4096
                     }
                 });
-                
+
                 this.sendToClient({
                     type: 'connected',
                     connection_type: 'websocket',
                     message: 'Connected via WebSocket - Ready to echo!'
                 });
             });
-            
+
             this.openaiWs.on('message', (data) => {
                 try {
                     const message = JSON.parse(data);
@@ -323,7 +334,7 @@ class WebSocketSessionHandler {
                     console.error('❌ Failed to parse OpenAI message:', error);
                 }
             });
-            
+
             this.openaiWs.on('close', (code, reason) => {
                 console.log(`🔌 OpenAI WebSocket connection closed: ${code} ${reason}`);
                 this.isConnectedToOpenAI = false;
@@ -332,7 +343,7 @@ class WebSocketSessionHandler {
                     message: 'Lost WebSocket connection to OpenAI'
                 });
             });
-            
+
             this.openaiWs.on('error', (error) => {
                 console.error('❌ OpenAI WebSocket error:', error);
                 this.sendToClient({
@@ -340,7 +351,6 @@ class WebSocketSessionHandler {
                     message: 'WebSocket connection error: ' + error.message
                 });
             });
-            
         } catch (error) {
             console.error('❌ Failed to connect to OpenAI via WebSocket:', error);
             this.sendToClient({
@@ -349,7 +359,7 @@ class WebSocketSessionHandler {
             });
         }
     }
-    
+
     handleClientMessage(message) {
         switch (message.type) {
             case 'audio_input':
@@ -357,20 +367,20 @@ class WebSocketSessionHandler {
                     // Convert the audio data to base64 for OpenAI
                     const audioBuffer = Buffer.from(new Int16Array(message.data).buffer);
                     const base64Audio = audioBuffer.toString('base64');
-                    
+
                     this.sendToOpenAI({
                         type: 'input_audio_buffer.append',
                         audio: base64Audio
                     });
                 }
                 break;
-                
+
             case 'commit_audio':
                 if (this.isConnectedToOpenAI) {
                     this.sendToOpenAI({
                         type: 'input_audio_buffer.commit'
                     });
-                    
+
                     this.sendToOpenAI({
                         type: 'response.create',
                         response: {
@@ -380,22 +390,22 @@ class WebSocketSessionHandler {
                     });
                 }
                 break;
-                
+
             default:
                 console.log('❓ Unknown client message type:', message.type);
         }
     }
-    
+
     handleOpenAIMessage(message) {
         switch (message.type) {
             case 'session.created':
                 console.log('📝 OpenAI session created:', message.session.id);
                 break;
-                
+
             case 'session.updated':
                 console.log('🔄 OpenAI session updated');
                 break;
-                
+
             case 'input_audio_buffer.speech_started':
                 console.log('🎤 Speech detected');
                 this.sendToClient({
@@ -403,7 +413,7 @@ class WebSocketSessionHandler {
                     message: 'Listening...'
                 });
                 break;
-                
+
             case 'input_audio_buffer.speech_stopped':
                 console.log('🛑 Speech ended');
                 this.sendToClient({
@@ -411,7 +421,7 @@ class WebSocketSessionHandler {
                     message: 'Processing...'
                 });
                 break;
-                
+
             case 'conversation.item.input_audio_transcription.completed':
                 console.log('📝 Transcribed:', message.transcript);
                 this.sendToClient({
@@ -419,14 +429,14 @@ class WebSocketSessionHandler {
                     transcript: message.transcript
                 });
                 break;
-                
+
             case 'response.audio.delta':
                 // Accumulate audio chunks
                 if (message.delta) {
                     this.audioBuffer.push(message.delta);
                 }
                 break;
-                
+
             case 'response.audio.done':
                 console.log('🔊 Audio response complete');
                 if (this.audioBuffer.length > 0) {
@@ -434,16 +444,16 @@ class WebSocketSessionHandler {
                     const completeAudio = this.audioBuffer.join('');
                     const audioData = Buffer.from(completeAudio, 'base64');
                     const audioArray = Array.from(new Int16Array(audioData.buffer));
-                    
+
                     this.sendToClient({
                         type: 'audio_output',
                         data: audioArray
                     });
-                    
+
                     this.audioBuffer = []; // Clear buffer
                 }
                 break;
-                
+
             case 'response.done':
                 console.log('✅ Response complete');
                 this.sendToClient({
@@ -451,7 +461,7 @@ class WebSocketSessionHandler {
                     message: 'Echo complete - Ready for next input'
                 });
                 break;
-                
+
             case 'error':
                 console.error('❌ OpenAI error:', message);
                 this.sendToClient({
@@ -459,7 +469,7 @@ class WebSocketSessionHandler {
                     message: message.error?.message || 'Unknown OpenAI error'
                 });
                 break;
-                
+
             default:
                 // Log other message types for debugging
                 if (process.env.DEBUG) {
@@ -467,19 +477,19 @@ class WebSocketSessionHandler {
                 }
         }
     }
-    
+
     sendToClient(message) {
         if (this.clientWs && this.clientWs.readyState === WebSocket.OPEN) {
             this.clientWs.send(JSON.stringify(message));
         }
     }
-    
+
     sendToOpenAI(message) {
         if (this.openaiWs && this.openaiWs.readyState === WebSocket.OPEN) {
             this.openaiWs.send(JSON.stringify(message));
         }
     }
-    
+
     cleanup() {
         if (this.openaiWs) {
             this.openaiWs.close();
@@ -487,5 +497,10 @@ class WebSocketSessionHandler {
     }
 }
 
-// Start the server
-new MultiModalVoiceServer();
+// Start the server only when executed directly (not when imported, e.g. in tests)
+const isMainModule = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMainModule) {
+    new MultiModalVoiceServer();
+}
+
+export { MultiModalVoiceServer, WebSocketSessionHandler };

--- a/src/middleware/error-middleware.js
+++ b/src/middleware/error-middleware.js
@@ -1,0 +1,82 @@
+/**
+ * Centralized Express error-handling and 404 middleware.
+ *
+ * Provides consistent OpenRouter-style error envelopes
+ * ({ error: { message, type } }), a JSON 404 handler for unknown routes,
+ * and credential-safe logging via redact().
+ */
+
+import { VoiceError, redact } from '../utils/error-handler.js';
+
+/**
+ * Map a VoiceError type to an appropriate HTTP status code.
+ * @param {string} type - VoiceError type
+ * @returns {number} HTTP status code
+ */
+export function statusForErrorType(type) {
+    switch (type) {
+        case 'AUTHENTICATION_ERROR':
+            return 401;
+        case 'AUTHORIZATION_ERROR':
+            return 403;
+        case 'NOT_FOUND':
+            return 404;
+        case 'RATE_LIMIT_ERROR':
+            return 429;
+        case 'TIMEOUT':
+            return 504;
+        case 'PROVIDER_UNAVAILABLE':
+        case 'SERVER_ERROR':
+        case 'NETWORK_ERROR':
+            return 502;
+        default:
+            return 500;
+    }
+}
+
+/**
+ * JSON 404 handler for unknown routes. Register AFTER all routes.
+ */
+export function notFoundHandler(req, res) {
+    res.status(404).json({
+        error: {
+            message: 'Not Found',
+            type: 'not_found'
+        }
+    });
+}
+
+/**
+ * Centralized 4-arg Express error-handling middleware. Register LAST.
+ * Produces a consistent { error: { message, type } } envelope and logs
+ * the failing request with credentials redacted.
+ */
+export function errorHandler(err, req, res, next) {
+    const isVoiceError = err instanceof VoiceError;
+    const type = isVoiceError ? err.type : 'internal_error';
+    const status = isVoiceError ? statusForErrorType(err.type) : 500;
+
+    // Log without leaking secrets from the request body or headers.
+    console.error('❌ Request error:', {
+        method: req.method,
+        path: req.originalUrl,
+        type,
+        message: err.message,
+        body: redact(req.body),
+        headers: redact(req.headers)
+    });
+
+    // If headers were already sent (e.g. streaming responses), delegate.
+    if (res.headersSent) {
+        return next(err);
+    }
+
+    res.status(status).json({
+        error: {
+            message: err.message || 'Internal Server Error',
+            type
+        }
+    });
+}
+
+export default { notFoundHandler, errorHandler, statusForErrorType };

--- a/src/routes/voice-api-endpoints.js
+++ b/src/routes/voice-api-endpoints.js
@@ -9,18 +9,27 @@ import ConfigManager from '../config/config-manager.js';
 import AnalyticsTracker from '../services/analytics-tracker.js';
 
 export class VoiceAPIEndpoints {
-    constructor(app) {
+    constructor(app, options = {}) {
         this.app = app;
         this.voiceRouter = new VoiceRouter();
         this.configManager = new ConfigManager();
         this.analyticsTracker = new AnalyticsTracker();
-        this.init();
+
+        // Routes do not depend on async state, so register them synchronously
+        // up front. This keeps route registration deterministic (important for
+        // tests and for the 404 handler ordering in the server).
+        this.setupRoutes();
+
+        // Background data loading (config + analytics persistence). Skippable
+        // in tests via { skipInit: true } to avoid timers/file IO.
+        if (!options.skipInit) {
+            this.init();
+        }
     }
 
     async init() {
         await this.configManager.init();
         await this.analyticsTracker.init();
-        this.setupRoutes();
     }
 
     setupRoutes() {
@@ -28,39 +37,45 @@ export class VoiceAPIEndpoints {
         this.app.get('/v1/voice/models', this.getModels.bind(this));
         this.app.get('/v1/voice/providers', this.getProviders.bind(this));
         this.app.get('/v1/voice/providers/:provider', this.getProviderDetails.bind(this));
-        
+
         // Voice Processing Endpoints (OpenRouter-style)
         this.app.post('/v1/voice/transcribe', this.transcribe.bind(this));
         this.app.post('/v1/voice/synthesize', this.synthesize.bind(this));
         this.app.post('/v1/voice/chat', this.chat.bind(this));
-        
+
         // WebSocket endpoint for real-time voice
         this.app.post('/v1/voice/realtime/session', this.createRealtimeSession.bind(this));
-        
+
         // Usage and Analytics
         this.app.get('/v1/voice/usage', this.getUsage.bind(this));
         this.app.get('/v1/voice/usage/:provider', this.getProviderUsage.bind(this));
-        
+
         // Provider validation
         this.app.post('/v1/voice/validate', this.validateProvider.bind(this));
-        
+
         // Configuration Management Endpoints
         this.app.post('/v1/voice/config/provider', this.saveProviderConfig.bind(this));
         this.app.get('/v1/voice/config/provider/:provider', this.getProviderConfig.bind(this));
-        this.app.delete('/v1/voice/config/provider/:provider', this.removeProviderConfig.bind(this));
+        this.app.delete(
+            '/v1/voice/config/provider/:provider',
+            this.removeProviderConfig.bind(this)
+        );
         this.app.get('/v1/voice/config/providers', this.getUserProviders.bind(this));
         this.app.post('/v1/voice/config/settings', this.updateUserSettings.bind(this));
         this.app.get('/v1/voice/config/settings', this.getUserSettings.bind(this));
         this.app.delete('/v1/voice/config/clear', this.clearUserConfig.bind(this));
         this.app.get('/v1/voice/config/export', this.exportUserConfig.bind(this));
-        
+
         // Health and Error Management Endpoints
         this.app.get('/v1/voice/health', this.getSystemHealth.bind(this));
         this.app.get('/v1/voice/health/:provider', this.getProviderHealth.bind(this));
-        this.app.post('/v1/voice/health/:provider/reset', this.resetProviderCircuitBreaker.bind(this));
+        this.app.post(
+            '/v1/voice/health/:provider/reset',
+            this.resetProviderCircuitBreaker.bind(this)
+        );
         this.app.get('/v1/voice/errors', this.getErrorStats.bind(this));
         this.app.get('/v1/voice/errors/:provider', this.getProviderErrors.bind(this));
-        
+
         // Analytics and Cost Tracking Endpoints
         this.app.get('/v1/voice/analytics', this.getAnalytics.bind(this));
         this.app.get('/v1/voice/analytics/:provider', this.getProviderAnalytics.bind(this));
@@ -75,9 +90,9 @@ export class VoiceAPIEndpoints {
     async getModels(req, res) {
         try {
             const models = [];
-            
+
             for (const [providerId, provider] of Object.entries(VOICE_PROVIDERS)) {
-                provider.models.forEach(model => {
+                provider.models.forEach((model) => {
                     models.push({
                         id: `${providerId}/${model}`,
                         object: 'model',
@@ -110,7 +125,7 @@ export class VoiceAPIEndpoints {
         try {
             const { type } = req.query;
             const providers = this.voiceRouter.listProviders(type);
-            
+
             res.json({
                 object: 'list',
                 data: Object.entries(providers).map(([id, config]) => ({
@@ -138,7 +153,7 @@ export class VoiceAPIEndpoints {
         try {
             const { provider } = req.params;
             const providerConfig = VOICE_PROVIDERS[provider];
-            
+
             if (!providerConfig) {
                 return res.status(404).json({ error: 'Provider not found' });
             }
@@ -160,27 +175,27 @@ export class VoiceAPIEndpoints {
     async transcribe(req, res) {
         const sessionId = this.generateSessionId();
         let session = null;
-        
+
         try {
-            const { 
-                provider, 
-                api_key, 
-                model, 
-                audio_file, 
+            const {
+                provider,
+                api_key,
+                model,
+                audio_file,
                 audio_url,
                 language = 'en',
-                options = {} 
+                options = {}
             } = req.body;
 
             if (!provider || !api_key) {
-                return res.status(400).json({ 
-                    error: 'Provider and api_key are required' 
+                return res.status(400).json({
+                    error: 'Provider and api_key are required'
                 });
             }
 
             if (!audio_file && !audio_url) {
-                return res.status(400).json({ 
-                    error: 'Either audio_file or audio_url is required' 
+                return res.status(400).json({
+                    error: 'Either audio_file or audio_url is required'
                 });
             }
 
@@ -238,10 +253,9 @@ export class VoiceAPIEndpoints {
                 confidence: result.confidence,
                 raw_response: result
             });
-
         } catch (error) {
             console.error('Transcription error:', error);
-            
+
             // Track error in analytics
             if (session) {
                 this.analyticsTracker.trackError(sessionId, {
@@ -249,8 +263,8 @@ export class VoiceAPIEndpoints {
                     message: error.message
                 });
             }
-            
-            res.status(500).json({ 
+
+            res.status(500).json({
                 error: error.message,
                 type: 'transcription_error'
             });
@@ -263,19 +277,19 @@ export class VoiceAPIEndpoints {
      */
     async synthesize(req, res) {
         try {
-            const { 
-                provider, 
-                api_key, 
-                model, 
-                text, 
-                voice, 
+            const {
+                provider,
+                api_key,
+                model,
+                text,
+                voice,
                 response_format = 'mp3',
-                options = {} 
+                options = {}
             } = req.body;
 
             if (!provider || !api_key || !text) {
-                return res.status(400).json({ 
-                    error: 'Provider, api_key, and text are required' 
+                return res.status(400).json({
+                    error: 'Provider, api_key, and text are required'
                 });
             }
 
@@ -303,10 +317,9 @@ export class VoiceAPIEndpoints {
                 text,
                 duration_estimate: Math.ceil(text.length / 15) // Rough estimate
             });
-
         } catch (error) {
             console.error('Synthesis error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'synthesis_error'
             });
@@ -319,19 +332,19 @@ export class VoiceAPIEndpoints {
      */
     async chat(req, res) {
         try {
-            const { 
-                provider, 
-                api_key, 
-                model, 
+            const {
+                provider,
+                api_key,
+                model,
                 messages = [],
                 voice = 'alloy',
                 stream = false,
-                options = {} 
+                options = {}
             } = req.body;
 
             if (!provider || !api_key || !messages.length) {
-                return res.status(400).json({ 
-                    error: 'Provider, api_key, and messages are required' 
+                return res.status(400).json({
+                    error: 'Provider, api_key, and messages are required'
                 });
             }
 
@@ -340,7 +353,7 @@ export class VoiceAPIEndpoints {
                 res.writeHead(200, {
                     'Content-Type': 'text/event-stream',
                     'Cache-Control': 'no-cache',
-                    'Connection': 'keep-alive',
+                    Connection: 'keep-alive',
                     'Access-Control-Allow-Origin': '*'
                 });
             }
@@ -359,33 +372,34 @@ export class VoiceAPIEndpoints {
                 adapter.onMessage((message) => {
                     res.write(`data: ${JSON.stringify(message)}\\n\\n`);
                 });
-                
+
                 // Send messages to provider
-                messages.forEach(msg => {
+                messages.forEach((msg) => {
                     adapter.send(msg);
                 });
             } else {
                 // Handle non-streaming response
                 const response = await adapter.process(messages, { voice, ...options });
-                
+
                 await adapter.disconnect();
 
                 res.json({
                     object: 'voice_chat_completion',
                     provider,
                     model,
-                    choices: [{
-                        index: 0,
-                        message: response.message || response,
-                        finish_reason: 'stop'
-                    }],
+                    choices: [
+                        {
+                            index: 0,
+                            message: response.message || response,
+                            finish_reason: 'stop'
+                        }
+                    ],
                     usage: response.usage || {}
                 });
             }
-
         } catch (error) {
             console.error('Chat error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'chat_error'
             });
@@ -398,17 +412,11 @@ export class VoiceAPIEndpoints {
      */
     async createRealtimeSession(req, res) {
         try {
-            const { 
-                provider, 
-                api_key, 
-                model, 
-                voice = 'alloy',
-                options = {} 
-            } = req.body;
+            const { provider, api_key, model, voice = 'alloy', options = {} } = req.body;
 
             if (!provider || !api_key) {
-                return res.status(400).json({ 
-                    error: 'Provider and api_key are required' 
+                return res.status(400).json({
+                    error: 'Provider and api_key are required'
                 });
             }
 
@@ -428,10 +436,9 @@ export class VoiceAPIEndpoints {
                 object: 'realtime_session',
                 ...sessionConfig
             });
-
         } catch (error) {
             console.error('Session creation error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'session_error'
             });
@@ -445,7 +452,7 @@ export class VoiceAPIEndpoints {
     async getUsage(req, res) {
         try {
             const stats = this.voiceRouter.getUsageStats();
-            
+
             res.json({
                 object: 'usage_stats',
                 total_providers: Object.keys(stats).length,
@@ -466,7 +473,7 @@ export class VoiceAPIEndpoints {
         try {
             const { provider } = req.params;
             const stats = this.voiceRouter.getUsageStats(provider);
-            
+
             if (!stats) {
                 return res.status(404).json({ error: 'Provider not found or no usage data' });
             }
@@ -490,17 +497,17 @@ export class VoiceAPIEndpoints {
             const { provider, api_key, options = {} } = req.body;
 
             if (!provider || !api_key) {
-                return res.status(400).json({ 
-                    error: 'Provider and api_key are required' 
+                return res.status(400).json({
+                    error: 'Provider and api_key are required'
                 });
             }
 
             const validation = this.voiceRouter.validateProvider(provider, api_key, options);
-            
+
             if (!validation.valid) {
-                return res.status(400).json({ 
-                    valid: false, 
-                    error: validation.error 
+                return res.status(400).json({
+                    valid: false,
+                    error: validation.error
                 });
             }
 
@@ -511,7 +518,7 @@ export class VoiceAPIEndpoints {
                     apiKey: api_key,
                     options
                 });
-                
+
                 await adapter.connect();
                 await adapter.disconnect();
 
@@ -527,7 +534,6 @@ export class VoiceAPIEndpoints {
                     error: `Connection failed: ${connectionError.message}`
                 });
             }
-
         } catch (error) {
             res.status(500).json({ error: error.message });
         }
@@ -540,10 +546,10 @@ export class VoiceAPIEndpoints {
 
         const url = new URL(baseURL);
         url.searchParams.set('api_key', apiKey);
-        
+
         if (options.model) url.searchParams.set('model', options.model);
         if (options.voice) url.searchParams.set('voice', options.voice);
-        
+
         return url.toString();
     }
 
@@ -569,8 +575,8 @@ export class VoiceAPIEndpoints {
             const userId = this.getUserId(req);
 
             if (!provider || !api_key) {
-                return res.status(400).json({ 
-                    error: 'Provider and api_key are required' 
+                return res.status(400).json({
+                    error: 'Provider and api_key are required'
                 });
             }
 
@@ -583,7 +589,7 @@ export class VoiceAPIEndpoints {
             });
 
             if (!validation.valid) {
-                return res.status(400).json({ 
+                return res.status(400).json({
                     error: 'Invalid configuration',
                     details: validation.errors
                 });
@@ -604,10 +610,9 @@ export class VoiceAPIEndpoints {
                 user_id: userId,
                 has_api_key: !!api_key
             });
-
         } catch (error) {
             console.error('Save provider config error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'config_save_error'
             });
@@ -626,8 +631,8 @@ export class VoiceAPIEndpoints {
             const config = this.configManager.getProviderConfig(userId, provider);
 
             if (!config) {
-                return res.status(404).json({ 
-                    error: 'Provider configuration not found' 
+                return res.status(404).json({
+                    error: 'Provider configuration not found'
                 });
             }
 
@@ -641,10 +646,9 @@ export class VoiceAPIEndpoints {
                 has_api_key: !!config.apiKey,
                 saved_at: config.savedAt
             });
-
         } catch (error) {
             console.error('Get provider config error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'config_get_error'
             });
@@ -663,8 +667,8 @@ export class VoiceAPIEndpoints {
             const result = await this.configManager.removeProviderConfig(userId, provider);
 
             if (!result.success) {
-                return res.status(404).json({ 
-                    error: result.error || 'Provider configuration not found' 
+                return res.status(404).json({
+                    error: result.error || 'Provider configuration not found'
                 });
             }
 
@@ -674,10 +678,9 @@ export class VoiceAPIEndpoints {
                 user_id: userId,
                 success: true
             });
-
         } catch (error) {
             console.error('Remove provider config error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'config_delete_error'
             });
@@ -699,10 +702,9 @@ export class VoiceAPIEndpoints {
                 providers,
                 total: providers.length
             });
-
         } catch (error) {
             console.error('Get user providers error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'providers_get_error'
             });
@@ -724,10 +726,9 @@ export class VoiceAPIEndpoints {
                 settings,
                 updated_at: new Date().toISOString()
             });
-
         } catch (error) {
             console.error('Update user settings error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'settings_update_error'
             });
@@ -748,10 +749,9 @@ export class VoiceAPIEndpoints {
                 user_id: userId,
                 settings
             });
-
         } catch (error) {
             console.error('Get user settings error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'settings_get_error'
             });
@@ -772,10 +772,9 @@ export class VoiceAPIEndpoints {
                 user_id: userId,
                 success: result.success
             });
-
         } catch (error) {
             console.error('Clear user config error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'config_clear_error'
             });
@@ -792,8 +791,8 @@ export class VoiceAPIEndpoints {
             const config = this.configManager.exportUserConfig(userId);
 
             if (!config) {
-                return res.status(404).json({ 
-                    error: 'No configuration found for user' 
+                return res.status(404).json({
+                    error: 'No configuration found for user'
                 });
             }
 
@@ -802,10 +801,9 @@ export class VoiceAPIEndpoints {
                 user_id: userId,
                 config
             });
-
         } catch (error) {
             console.error('Export user config error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'config_export_error'
             });
@@ -821,16 +819,15 @@ export class VoiceAPIEndpoints {
     async getSystemHealth(req, res) {
         try {
             const health = this.voiceRouter.getSystemHealth();
-            
+
             res.json({
                 object: 'system_health',
                 ...health,
                 timestamp: new Date().toISOString()
             });
-
         } catch (error) {
             console.error('Get system health error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'health_check_error'
             });
@@ -848,8 +845,8 @@ export class VoiceAPIEndpoints {
             const isAvailable = this.voiceRouter.isProviderAvailable(provider);
 
             if (!errorStats) {
-                return res.status(404).json({ 
-                    error: 'Provider not found' 
+                return res.status(404).json({
+                    error: 'Provider not found'
                 });
             }
 
@@ -860,10 +857,9 @@ export class VoiceAPIEndpoints {
                 ...errorStats,
                 timestamp: new Date().toISOString()
             });
-
         } catch (error) {
             console.error('Get provider health error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'provider_health_error'
             });
@@ -877,10 +873,10 @@ export class VoiceAPIEndpoints {
     async resetProviderCircuitBreaker(req, res) {
         try {
             const { provider } = req.params;
-            
+
             if (!VOICE_PROVIDERS[provider]) {
-                return res.status(404).json({ 
-                    error: 'Provider not found' 
+                return res.status(404).json({
+                    error: 'Provider not found'
                 });
             }
 
@@ -892,10 +888,9 @@ export class VoiceAPIEndpoints {
                 success: true,
                 timestamp: new Date().toISOString()
             });
-
         } catch (error) {
             console.error('Reset circuit breaker error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'circuit_breaker_reset_error'
             });
@@ -909,16 +904,15 @@ export class VoiceAPIEndpoints {
     async getErrorStats(req, res) {
         try {
             const stats = this.voiceRouter.getErrorStats();
-            
+
             res.json({
                 object: 'error_statistics',
                 stats,
                 timestamp: new Date().toISOString()
             });
-
         } catch (error) {
             console.error('Get error stats error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'error_stats_error'
             });
@@ -935,8 +929,8 @@ export class VoiceAPIEndpoints {
             const stats = this.voiceRouter.getErrorStats(provider);
 
             if (!stats) {
-                return res.status(404).json({ 
-                    error: 'Provider not found or no error data' 
+                return res.status(404).json({
+                    error: 'Provider not found or no error data'
                 });
             }
 
@@ -946,10 +940,9 @@ export class VoiceAPIEndpoints {
                 ...stats,
                 timestamp: new Date().toISOString()
             });
-
         } catch (error) {
             console.error('Get provider errors error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'provider_errors_error'
             });
@@ -964,11 +957,7 @@ export class VoiceAPIEndpoints {
      */
     async getAnalytics(req, res) {
         try {
-            const { 
-                provider, 
-                timeRange, 
-                operation 
-            } = req.query;
+            const { provider, timeRange, operation } = req.query;
 
             const analytics = this.analyticsTracker.getAnalytics({
                 provider,
@@ -981,10 +970,9 @@ export class VoiceAPIEndpoints {
                 ...analytics,
                 timestamp: new Date().toISOString()
             });
-
         } catch (error) {
             console.error('Get analytics error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'analytics_error'
             });
@@ -1001,8 +989,8 @@ export class VoiceAPIEndpoints {
             const { timeRange, operation } = req.query;
 
             if (!VOICE_PROVIDERS[provider]) {
-                return res.status(404).json({ 
-                    error: 'Provider not found' 
+                return res.status(404).json({
+                    error: 'Provider not found'
                 });
             }
 
@@ -1018,10 +1006,9 @@ export class VoiceAPIEndpoints {
                 ...analytics,
                 timestamp: new Date().toISOString()
             });
-
         } catch (error) {
             console.error('Get provider analytics error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'provider_analytics_error'
             });
@@ -1041,10 +1028,9 @@ export class VoiceAPIEndpoints {
                 ...report,
                 timestamp: new Date().toISOString()
             });
-
         } catch (error) {
             console.error('Get cost report error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'cost_report_error'
             });
@@ -1058,10 +1044,10 @@ export class VoiceAPIEndpoints {
     async getCostReportByPeriod(req, res) {
         try {
             const { period } = req.params;
-            
+
             if (!['hour', 'day', 'week', 'month'].includes(period)) {
-                return res.status(400).json({ 
-                    error: 'Invalid period. Must be: hour, day, week, or month' 
+                return res.status(400).json({
+                    error: 'Invalid period. Must be: hour, day, week, or month'
                 });
             }
 
@@ -1072,19 +1058,13 @@ export class VoiceAPIEndpoints {
                 ...report,
                 timestamp: new Date().toISOString()
             });
-
         } catch (error) {
             console.error('Get cost report by period error:', error);
-            res.status(500).json({ 
+            res.status(500).json({
                 error: error.message,
                 type: 'cost_report_period_error'
             });
         }
-    }
-
-    // Helper method to generate session ID
-    generateSessionId() {
-        return 'sess_' + Math.random().toString(36).substr(2, 16) + Date.now().toString(36);
     }
 }
 

--- a/src/routes/voice-router.js
+++ b/src/routes/voice-router.js
@@ -12,7 +12,7 @@ export class VoiceRouter {
         this.providers = VOICE_PROVIDERS;
         this.activeConnections = new Map();
         this.usage = new Map(); // Track usage per provider
-        
+
         // Initialize error handler
         this.errorHandler = new VoiceErrorHandler({
             maxRetries: options.maxRetries || 3,
@@ -35,7 +35,9 @@ export class VoiceRouter {
         const { provider, apiKey, options = {}, type } = config;
 
         if (!this.providers[provider]) {
-            throw new Error(`Provider "${provider}" not supported. Available providers: ${Object.keys(this.providers).join(', ')}`);
+            throw new Error(
+                `Provider "${provider}" not supported. Available providers: ${Object.keys(this.providers).join(', ')}`
+            );
         }
 
         if (!apiKey) {
@@ -46,7 +48,9 @@ export class VoiceRouter {
 
         // Validate provider supports requested type
         if (type && !providerConfig.capabilities.includes(type) && providerConfig.type !== type) {
-            throw new Error(`Provider "${provider}" does not support "${type}". Supported: ${providerConfig.capabilities.join(', ')}`);
+            throw new Error(
+                `Provider "${provider}" does not support "${type}". Supported: ${providerConfig.capabilities.join(', ')}`
+            );
         }
 
         // Create appropriate adapter based on provider
@@ -65,17 +69,17 @@ export class VoiceRouter {
     getAdapterClass(provider) {
         const adapterMap = {
             'openai-realtime': OpenAIRealtimeAdapter,
-            'deepgram': DeepgramAdapter,
-            'assemblyai': AssemblyAIAdapter,
-            'whisper': WhisperAdapter,
-            'elevenlabs': ElevenLabsAdapter,
-            'playht': PlayHTAdapter,
+            deepgram: DeepgramAdapter,
+            assemblyai: AssemblyAIAdapter,
+            whisper: WhisperAdapter,
+            elevenlabs: ElevenLabsAdapter,
+            playht: PlayHTAdapter,
             'google-stt': GoogleSTTAdapter,
             'google-tts': GoogleTTSAdapter,
             'azure-stt': AzureSTTAdapter,
             'azure-tts': AzureTTSAdapter,
             'amazon-polly': AmazonPollyAdapter,
-            'murf': MurfAdapter,
+            murf: MurfAdapter,
             'elevenlabs-conversational': ElevenLabsConversationalAdapter,
             'ibm-watson': IBMWatsonAdapter
         };
@@ -101,7 +105,7 @@ export class VoiceRouter {
         }
 
         const stats = this.usage.get(provider);
-        
+
         switch (action) {
             case 'request':
                 stats.requests++;
@@ -163,7 +167,7 @@ export class VoiceRouter {
      */
     async routeWithFallback(config) {
         const { provider, fallbackProviders = [], ...restConfig } = config;
-        
+
         return await this.errorHandler.executeWithFallback(
             () => this.routeRequest({ provider, ...restConfig }),
             {
@@ -240,10 +244,10 @@ class OpenAIRealtimeAdapter extends BaseAdapter {
     async connect() {
         return new Promise((resolve, reject) => {
             const url = `${this.config.endpoint}?model=${this.options.model || 'gpt-4o-realtime-preview-2024-12-17'}`;
-            
+
             this.websocket = new WebSocket(url, {
                 headers: {
-                    'Authorization': `Bearer ${this.apiKey}`,
+                    Authorization: `Bearer ${this.apiKey}`,
                     'OpenAI-Beta': 'realtime=v1'
                 }
             });
@@ -251,20 +255,23 @@ class OpenAIRealtimeAdapter extends BaseAdapter {
             this.websocket.on('open', () => {
                 this.isConnected = true;
                 // Send session configuration
-                this.websocket.send(JSON.stringify({
-                    type: 'session.update',
-                    session: {
-                        modalities: ['text', 'audio'],
-                        instructions: this.options.instructions || 'You are a helpful assistant.',
-                        voice: this.options.voice || 'alloy',
-                        input_audio_format: 'pcm16',
-                        output_audio_format: 'pcm16',
-                        input_audio_transcription: { model: 'whisper-1' },
-                        turn_detection: { type: 'server_vad', threshold: 0.5 },
-                        temperature: this.options.temperature || 0.6,
-                        max_response_output_tokens: this.options.max_tokens || 4096
-                    }
-                }));
+                this.websocket.send(
+                    JSON.stringify({
+                        type: 'session.update',
+                        session: {
+                            modalities: ['text', 'audio'],
+                            instructions:
+                                this.options.instructions || 'You are a helpful assistant.',
+                            voice: this.options.voice || 'alloy',
+                            input_audio_format: 'pcm16',
+                            output_audio_format: 'pcm16',
+                            input_audio_transcription: { model: 'whisper-1' },
+                            turn_detection: { type: 'server_vad', threshold: 0.5 },
+                            temperature: this.options.temperature || 0.6,
+                            max_response_output_tokens: this.options.max_tokens || 4096
+                        }
+                    })
+                );
                 resolve();
             });
 
@@ -307,11 +314,11 @@ class ElevenLabsAdapter extends BaseAdapter {
     async process(text, options = {}) {
         const voiceId = options.voice_id || 'pNInz6obpgDQGcFmaJgB'; // Default voice
         const model = options.model || 'eleven_multilingual_v2';
-        
+
         const response = await fetch(`${this.config.endpoint}/${voiceId}`, {
             method: 'POST',
             headers: {
-                'Accept': 'audio/mpeg',
+                Accept: 'audio/mpeg',
                 'Content-Type': 'application/json',
                 'xi-api-key': this.apiKey
             },
@@ -358,10 +365,10 @@ class DeepgramAdapter extends BaseAdapter {
             });
 
             const url = `${this.config.endpoint}?${params}`;
-            
+
             this.websocket = new WebSocket(url, {
                 headers: {
-                    'Authorization': `Token ${this.apiKey}`
+                    Authorization: `Token ${this.apiKey}`
                 }
             });
 
@@ -420,7 +427,7 @@ class WhisperAdapter extends BaseAdapter {
         const response = await fetch(this.config.endpoint, {
             method: 'POST',
             headers: {
-                'Authorization': `Bearer ${this.apiKey}`
+                Authorization: `Bearer ${this.apiKey}`
             },
             body: formData
         });
@@ -436,53 +443,93 @@ class WhisperAdapter extends BaseAdapter {
 
 // Placeholder adapters for other providers (to be implemented)
 class AssemblyAIAdapter extends BaseAdapter {
-    async connect() { this.isConnected = true; }
-    async process(input) { throw new Error('AssemblyAI adapter not yet implemented'); }
+    async connect() {
+        this.isConnected = true;
+    }
+    async process(input) {
+        throw new Error('AssemblyAI adapter not yet implemented');
+    }
 }
 
 class PlayHTAdapter extends BaseAdapter {
-    async connect() { this.isConnected = true; }
-    async process(input) { throw new Error('PlayHT adapter not yet implemented'); }
+    async connect() {
+        this.isConnected = true;
+    }
+    async process(input) {
+        throw new Error('PlayHT adapter not yet implemented');
+    }
 }
 
 class GoogleSTTAdapter extends BaseAdapter {
-    async connect() { this.isConnected = true; }
-    async process(input) { throw new Error('Google STT adapter not yet implemented'); }
+    async connect() {
+        this.isConnected = true;
+    }
+    async process(input) {
+        throw new Error('Google STT adapter not yet implemented');
+    }
 }
 
 class GoogleTTSAdapter extends BaseAdapter {
-    async connect() { this.isConnected = true; }
-    async process(input) { throw new Error('Google TTS adapter not yet implemented'); }
+    async connect() {
+        this.isConnected = true;
+    }
+    async process(input) {
+        throw new Error('Google TTS adapter not yet implemented');
+    }
 }
 
 class AzureSTTAdapter extends BaseAdapter {
-    async connect() { this.isConnected = true; }
-    async process(input) { throw new Error('Azure STT adapter not yet implemented'); }
+    async connect() {
+        this.isConnected = true;
+    }
+    async process(input) {
+        throw new Error('Azure STT adapter not yet implemented');
+    }
 }
 
 class AzureTTSAdapter extends BaseAdapter {
-    async connect() { this.isConnected = true; }
-    async process(input) { throw new Error('Azure TTS adapter not yet implemented'); }
+    async connect() {
+        this.isConnected = true;
+    }
+    async process(input) {
+        throw new Error('Azure TTS adapter not yet implemented');
+    }
 }
 
 class AmazonPollyAdapter extends BaseAdapter {
-    async connect() { this.isConnected = true; }
-    async process(input) { throw new Error('Amazon Polly adapter not yet implemented'); }
+    async connect() {
+        this.isConnected = true;
+    }
+    async process(input) {
+        throw new Error('Amazon Polly adapter not yet implemented');
+    }
 }
 
 class MurfAdapter extends BaseAdapter {
-    async connect() { this.isConnected = true; }
-    async process(input) { throw new Error('Murf adapter not yet implemented'); }
+    async connect() {
+        this.isConnected = true;
+    }
+    async process(input) {
+        throw new Error('Murf adapter not yet implemented');
+    }
 }
 
 class ElevenLabsConversationalAdapter extends BaseAdapter {
-    async connect() { this.isConnected = true; }
-    async process(input) { throw new Error('ElevenLabs Conversational adapter not yet implemented'); }
+    async connect() {
+        this.isConnected = true;
+    }
+    async process(input) {
+        throw new Error('ElevenLabs Conversational adapter not yet implemented');
+    }
 }
 
 class IBMWatsonAdapter extends BaseAdapter {
-    async connect() { this.isConnected = true; }
-    async process(input) { throw new Error('IBM Watson adapter not yet implemented'); }
+    async connect() {
+        this.isConnected = true;
+    }
+    async process(input) {
+        throw new Error('IBM Watson adapter not yet implemented');
+    }
 }
 
 export default VoiceRouter;

--- a/src/services/analytics-tracker.js
+++ b/src/services/analytics-tracker.js
@@ -16,7 +16,7 @@ export class AnalyticsTracker {
         this.sessionStart = new Date();
         this.flushInterval = options.flushInterval || 60000; // 1 minute
         this.maxMemoryEntries = options.maxMemoryEntries || 1000;
-        
+
         // In-memory analytics data
         this.sessions = new Map();
         this.metrics = {
@@ -36,34 +36,34 @@ export class AnalyticsTracker {
         this.costTables = {
             'openai-realtime': {
                 type: 'per-minute',
-                inputCost: 0.06,  // $0.06 per minute input
+                inputCost: 0.06, // $0.06 per minute input
                 outputCost: 0.24, // $0.24 per minute output
                 currency: 'USD'
             },
-            'deepgram': {
+            deepgram: {
                 type: 'per-minute',
                 preRecordedCost: 0.0043, // $0.0043 per minute
-                streamingCost: 0.0077,   // $0.0077 per minute
+                streamingCost: 0.0077, // $0.0077 per minute
                 currency: 'USD'
             },
-            'assemblyai': {
+            assemblyai: {
                 type: 'per-hour',
-                asyncCost: 0.37,      // $0.37 per hour
-                realtimeCost: 0.47,   // $0.47 per hour
+                asyncCost: 0.37, // $0.37 per hour
+                realtimeCost: 0.47, // $0.47 per hour
                 currency: 'USD'
             },
-            'whisper': {
+            whisper: {
                 type: 'per-minute',
-                cost: 0.006,  // $0.006 per minute
+                cost: 0.006, // $0.006 per minute
                 currency: 'USD'
             },
-            'elevenlabs': {
+            elevenlabs: {
                 type: 'per-character',
-                creatorCost: 0.0003,  // $0.30 per 1k characters
-                proCost: 0.00024,     // $0.24 per 1k characters
+                creatorCost: 0.0003, // $0.30 per 1k characters
+                proCost: 0.00024, // $0.24 per 1k characters
                 currency: 'USD'
             },
-            'playht': {
+            playht: {
                 type: 'per-character',
                 estimatedCost: 0.0002, // Estimated based on usage-based pricing
                 currency: 'USD'
@@ -132,8 +132,10 @@ export class AnalyticsTracker {
         // Update hourly requests
         const hour = new Date().getHours();
         const hourKey = `${new Date().toDateString()}-${hour}`;
-        this.metrics.requestsByHour.set(hourKey, 
-            (this.metrics.requestsByHour.get(hourKey) || 0) + 1);
+        this.metrics.requestsByHour.set(
+            hourKey,
+            (this.metrics.requestsByHour.get(hourKey) || 0) + 1
+        );
 
         return session;
     }
@@ -220,35 +222,42 @@ export class AnalyticsTracker {
         const usage = session.usage;
 
         switch (costTable.type) {
-            case 'per-minute':
+            case 'per-minute': {
                 const minutes = Math.max(session.duration / 60000, 0.1); // Minimum 0.1 minute
-                
+
                 if (session.provider === 'openai-realtime') {
-                    cost = (usage.inputTokens || 0) * costTable.inputCost / 1000000 * 60; // Convert tokens to minutes
-                    cost += (usage.outputTokens || 0) * costTable.outputCost / 1000000 * 60;
+                    cost = (((usage.inputTokens || 0) * costTable.inputCost) / 1000000) * 60; // Convert tokens to minutes
+                    cost += (((usage.outputTokens || 0) * costTable.outputCost) / 1000000) * 60;
                 } else if (session.provider === 'deepgram') {
                     const isStreaming = session.operation === 'realtime';
-                    cost = minutes * (isStreaming ? costTable.streamingCost : costTable.preRecordedCost);
+                    cost =
+                        minutes *
+                        (isStreaming ? costTable.streamingCost : costTable.preRecordedCost);
                 } else {
                     cost = minutes * (costTable.cost || 0);
                 }
                 break;
+            }
 
-            case 'per-hour':
+            case 'per-hour': {
                 const hours = Math.max(session.duration / 3600000, 0.01); // Minimum 0.01 hour
                 const isRealtime = session.operation === 'realtime';
                 cost = hours * (isRealtime ? costTable.realtimeCost : costTable.asyncCost);
                 break;
+            }
 
-            case 'per-character':
+            case 'per-character': {
                 const characters = usage.characters || session.metadata.textLength || 0;
                 if (session.provider === 'elevenlabs') {
                     // Assume Pro tier pricing as default
                     cost = characters * costTable.proCost;
                 } else {
-                    cost = characters * (costTable.cost || costTable.estimatedCost || costTable.neuralCost || 0);
+                    cost =
+                        characters *
+                        (costTable.cost || costTable.estimatedCost || costTable.neuralCost || 0);
                 }
                 break;
+            }
 
             default:
                 cost = 0;
@@ -278,17 +287,19 @@ export class AnalyticsTracker {
         providerStats.requests++;
         providerStats.totalDuration += session.duration;
         providerStats.totalCost += session.cost;
-        
+
         if (session.success) {
             providerStats.successfulRequests++;
         }
-        
+
         providerStats.averageResponseTime = providerStats.totalDuration / providerStats.requests;
-        providerStats.errorRate = 1 - (providerStats.successfulRequests / providerStats.requests);
+        providerStats.errorRate = 1 - providerStats.successfulRequests / providerStats.requests;
 
         // Update cost tracking
-        this.metrics.costByProvider.set(session.provider, 
-            (this.metrics.costByProvider.get(session.provider) || 0) + session.cost);
+        this.metrics.costByProvider.set(
+            session.provider,
+            (this.metrics.costByProvider.get(session.provider) || 0) + session.cost
+        );
 
         // Update global metrics
         this.metrics.totalCost += session.cost;
@@ -302,34 +313,30 @@ export class AnalyticsTracker {
      * @returns {Object} Analytics summary
      */
     getAnalytics(options = {}) {
-        const { 
-            provider = null, 
-            timeRange = null, 
-            operation = null 
-        } = options;
+        const { provider = null, timeRange = null, operation = null } = options;
 
         let filteredSessions = Array.from(this.sessions.values());
 
         // Apply filters
         if (provider) {
-            filteredSessions = filteredSessions.filter(s => s.provider === provider);
+            filteredSessions = filteredSessions.filter((s) => s.provider === provider);
         }
 
         if (operation) {
-            filteredSessions = filteredSessions.filter(s => s.operation === operation);
+            filteredSessions = filteredSessions.filter((s) => s.operation === operation);
         }
 
         if (timeRange) {
             const now = Date.now();
-            const cutoff = now - (timeRange * 60 * 1000); // timeRange in minutes
-            filteredSessions = filteredSessions.filter(s => s.startTime >= cutoff);
+            const cutoff = now - timeRange * 60 * 1000; // timeRange in minutes
+            filteredSessions = filteredSessions.filter((s) => s.startTime >= cutoff);
         }
 
         // Calculate filtered metrics
         const analytics = {
             summary: {
                 totalSessions: filteredSessions.length,
-                successfulSessions: filteredSessions.filter(s => s.success).length,
+                successfulSessions: filteredSessions.filter((s) => s.success).length,
                 totalCost: filteredSessions.reduce((sum, s) => sum + s.cost, 0),
                 totalDuration: filteredSessions.reduce((sum, s) => sum + (s.duration || 0), 0),
                 averageResponseTime: 0,
@@ -347,13 +354,15 @@ export class AnalyticsTracker {
 
         // Calculate derived metrics
         if (analytics.summary.totalSessions > 0) {
-            analytics.summary.averageResponseTime = analytics.summary.totalDuration / analytics.summary.totalSessions;
-            analytics.summary.errorRate = 1 - (analytics.summary.successfulSessions / analytics.summary.totalSessions);
+            analytics.summary.averageResponseTime =
+                analytics.summary.totalDuration / analytics.summary.totalSessions;
+            analytics.summary.errorRate =
+                1 - analytics.summary.successfulSessions / analytics.summary.totalSessions;
         }
 
         // Group by provider
         const providerGroups = {};
-        filteredSessions.forEach(session => {
+        filteredSessions.forEach((session) => {
             if (!providerGroups[session.provider]) {
                 providerGroups[session.provider] = [];
             }
@@ -366,7 +375,7 @@ export class AnalyticsTracker {
 
         // Group by operation
         const operationGroups = {};
-        filteredSessions.forEach(session => {
+        filteredSessions.forEach((session) => {
             if (!operationGroups[session.operation]) {
                 operationGroups[session.operation] = [];
             }
@@ -384,14 +393,14 @@ export class AnalyticsTracker {
      * Calculate metrics for a group of sessions
      */
     calculateGroupMetrics(sessions) {
-        const successful = sessions.filter(s => s.success);
+        const successful = sessions.filter((s) => s.success);
         const totalCost = sessions.reduce((sum, s) => sum + s.cost, 0);
         const totalDuration = sessions.reduce((sum, s) => sum + (s.duration || 0), 0);
 
         return {
             sessions: sessions.length,
             successful: successful.length,
-            errorRate: 1 - (successful.length / sessions.length),
+            errorRate: 1 - successful.length / sessions.length,
             totalCost,
             averageCost: totalCost / sessions.length,
             totalDuration,
@@ -416,8 +425,8 @@ export class AnalyticsTracker {
     getPerformanceMetrics(sessions) {
         if (sessions.length === 0) return {};
 
-        const durations = sessions.map(s => s.duration || 0).sort((a, b) => a - b);
-        const costs = sessions.map(s => s.cost).sort((a, b) => a - b);
+        const durations = sessions.map((s) => s.duration || 0).sort((a, b) => a - b);
+        const costs = sessions.map((s) => s.cost).sort((a, b) => a - b);
 
         return {
             responseTime: {
@@ -462,8 +471,8 @@ export class AnalyticsTracker {
                 startTime = new Date(now.getTime() - 24 * 60 * 60 * 1000);
         }
 
-        const analytics = this.getAnalytics({ 
-            timeRange: (now.getTime() - startTime.getTime()) / (60 * 1000) 
+        const analytics = this.getAnalytics({
+            timeRange: (now.getTime() - startTime.getTime()) / (60 * 1000)
         });
 
         return {
@@ -473,10 +482,12 @@ export class AnalyticsTracker {
             totalCost: analytics.summary.totalCost,
             costByProvider: analytics.costBreakdown,
             topProviders: Object.entries(analytics.costByProvider)
-                .sort(([,a], [,b]) => b - a)
+                .sort(([, a], [, b]) => b - a)
                 .slice(0, 5),
             sessions: analytics.summary.totalSessions,
-            estimatedMonthlyCost: analytics.summary.totalCost * (30 * 24 * 60 * 60 * 1000) / (now.getTime() - startTime.getTime())
+            estimatedMonthlyCost:
+                (analytics.summary.totalCost * (30 * 24 * 60 * 60 * 1000)) /
+                (now.getTime() - startTime.getTime())
         };
     }
 
@@ -487,7 +498,7 @@ export class AnalyticsTracker {
         try {
             const data = await fs.readFile(this.analyticsFile, 'utf8');
             const parsed = JSON.parse(data);
-            
+
             // Restore metrics
             if (parsed.metrics) {
                 this.metrics = {
@@ -537,7 +548,8 @@ export class AnalyticsTracker {
     /**
      * Cleanup old data
      */
-    async cleanup(maxAge = 7 * 24 * 60 * 60 * 1000) { // 7 days default
+    async cleanup(maxAge = 7 * 24 * 60 * 60 * 1000) {
+        // 7 days default
         const cutoff = Date.now() - maxAge;
         let removed = 0;
 
@@ -549,7 +561,7 @@ export class AnalyticsTracker {
         }
 
         // Clean up hourly data older than 30 days
-        const hourCutoff = Date.now() - (30 * 24 * 60 * 60 * 1000);
+        const hourCutoff = Date.now() - 30 * 24 * 60 * 60 * 1000;
         for (const [hourKey] of this.metrics.requestsByHour) {
             const [dateStr] = hourKey.split('-');
             if (new Date(dateStr).getTime() < hourCutoff) {

--- a/src/utils/error-handler.js
+++ b/src/utils/error-handler.js
@@ -10,26 +10,36 @@ export class VoiceErrorHandler {
         this.fallbackProviders = options.fallbackProviders || [];
         this.circuitBreakerThreshold = options.circuitBreakerThreshold || 5;
         this.circuitBreakerTimeout = options.circuitBreakerTimeout || 30000;
-        
+
         // Circuit breaker state per provider
         this.circuitBreakers = new Map();
-        
+
         // Error statistics
         this.errorStats = new Map();
-        
+
         this.initializeCircuitBreakers();
     }
 
     initializeCircuitBreakers() {
         // Initialize circuit breaker for each provider
         const providers = [
-            'openai-realtime', 'deepgram', 'assemblyai', 'whisper',
-            'elevenlabs', 'playht', 'google-stt', 'google-tts',
-            'azure-stt', 'azure-tts', 'amazon-polly', 'murf',
-            'elevenlabs-conversational', 'ibm-watson'
+            'openai-realtime',
+            'deepgram',
+            'assemblyai',
+            'whisper',
+            'elevenlabs',
+            'playht',
+            'google-stt',
+            'google-tts',
+            'azure-stt',
+            'azure-tts',
+            'amazon-polly',
+            'murf',
+            'elevenlabs-conversational',
+            'ibm-watson'
         ];
 
-        providers.forEach(provider => {
+        providers.forEach((provider) => {
             this.circuitBreakers.set(provider, {
                 state: 'CLOSED', // CLOSED, OPEN, HALF_OPEN
                 failures: 0,
@@ -79,13 +89,12 @@ export class VoiceErrorHandler {
         for (attempt = 0; attempt <= retries; attempt++) {
             try {
                 this.recordRequest(provider);
-                
+
                 const result = await this.executeWithTimeout(operation, timeout);
-                
+
                 // Success - reset circuit breaker
                 this.recordSuccess(provider, Date.now() - startTime);
                 return result;
-
             } catch (error) {
                 lastError = this.createVoiceError(error, provider, attempt);
                 this.recordError(provider, lastError, Date.now() - startTime);
@@ -113,18 +122,17 @@ export class VoiceErrorHandler {
 
             try {
                 console.log(`🔄 Falling back to provider: ${fallbackProvider}`);
-                
+
                 this.recordRequest(fallbackProvider);
                 const result = await this.executeWithTimeout(operation, timeout);
-                
+
                 this.recordSuccess(fallbackProvider, Date.now() - startTime);
                 return result;
-
             } catch (error) {
                 const fallbackError = this.createVoiceError(error, fallbackProvider, 0);
                 this.recordError(fallbackProvider, fallbackError, Date.now() - startTime);
                 this.updateCircuitBreaker(fallbackProvider, fallbackError);
-                
+
                 console.log(`❌ Fallback provider ${fallbackProvider} also failed:`, error.message);
             }
         }
@@ -152,11 +160,11 @@ export class VoiceErrorHandler {
             }, timeout);
 
             Promise.resolve(operation())
-                .then(result => {
+                .then((result) => {
                     clearTimeout(timer);
                     resolve(result);
                 })
-                .catch(error => {
+                .catch((error) => {
                     clearTimeout(timer);
                     reject(error);
                 });
@@ -173,7 +181,7 @@ export class VoiceErrorHandler {
         switch (breaker.state) {
             case 'CLOSED':
                 return true;
-            
+
             case 'OPEN':
                 // Check if we should try half-open
                 if (Date.now() >= breaker.nextAttemptTime) {
@@ -181,10 +189,10 @@ export class VoiceErrorHandler {
                     return true;
                 }
                 return false;
-            
+
             case 'HALF_OPEN':
                 return true;
-            
+
             default:
                 return true;
         }
@@ -204,13 +212,15 @@ export class VoiceErrorHandler {
         if (breaker.failures >= this.circuitBreakerThreshold && breaker.state === 'CLOSED') {
             breaker.state = 'OPEN';
             breaker.nextAttemptTime = Date.now() + this.circuitBreakerTimeout;
-            
-            console.log(`🚨 Circuit breaker OPENED for provider: ${provider} (${breaker.failures} failures)`);
+
+            console.log(
+                `🚨 Circuit breaker OPENED for provider: ${provider} (${breaker.failures} failures)`
+            );
         } else if (breaker.state === 'HALF_OPEN') {
             // Half-open failed, go back to open
             breaker.state = 'OPEN';
             breaker.nextAttemptTime = Date.now() + this.circuitBreakerTimeout;
-            
+
             console.log(`🚨 Circuit breaker back to OPEN for provider: ${provider}`);
         }
     }
@@ -222,7 +232,7 @@ export class VoiceErrorHandler {
         const breaker = this.circuitBreakers.get(provider);
         if (breaker) {
             breaker.failures = 0;
-            
+
             if (breaker.state === 'HALF_OPEN') {
                 breaker.state = 'CLOSED';
                 console.log(`✅ Circuit breaker CLOSED for provider: ${provider}`);
@@ -260,7 +270,7 @@ export class VoiceErrorHandler {
                 timestamp: new Date().toISOString()
             };
             stats.errorRate = stats.totalErrors / stats.totalRequests;
-            
+
             // Track error types
             const errorType = error.type || 'UNKNOWN';
             stats.errorTypes[errorType] = (stats.errorTypes[errorType] || 0) + 1;
@@ -292,7 +302,11 @@ export class VoiceErrorHandler {
             isRetryable = false;
         } else if (error.message.includes('429') || error.message.includes('rate limit')) {
             type = 'RATE_LIMIT_ERROR';
-        } else if (error.message.includes('500') || error.message.includes('502') || error.message.includes('503')) {
+        } else if (
+            error.message.includes('500') ||
+            error.message.includes('502') ||
+            error.message.includes('503')
+        ) {
             type = 'SERVER_ERROR';
         } else if (error.message.includes('ENOTFOUND') || error.message.includes('ECONNREFUSED')) {
             type = 'NETWORK_ERROR';
@@ -314,11 +328,11 @@ export class VoiceErrorHandler {
     calculateRetryDelay(attempt) {
         const baseDelay = this.retryDelay;
         const maxDelay = 30000; // 30 seconds max
-        
+
         // Exponential backoff with jitter
         const exponentialDelay = baseDelay * Math.pow(2, attempt);
         const jitter = Math.random() * 1000;
-        
+
         return Math.min(exponentialDelay + jitter, maxDelay);
     }
 
@@ -326,7 +340,7 @@ export class VoiceErrorHandler {
      * Delay utility
      */
     delay(ms) {
-        return new Promise(resolve => setTimeout(resolve, ms));
+        return new Promise((resolve) => setTimeout(resolve, ms));
     }
 
     /**
@@ -362,7 +376,7 @@ export class VoiceErrorHandler {
             breaker.failures = 0;
             breaker.lastFailureTime = null;
             breaker.nextAttemptTime = null;
-            
+
             console.log(`🔄 Circuit breaker manually reset for provider: ${provider}`);
         }
     }
@@ -384,7 +398,7 @@ export class VoiceErrorHandler {
 
         for (const [provider, stats] of this.errorStats) {
             const breaker = this.circuitBreakers.get(provider);
-            
+
             let providerStatus = 'healthy';
             if (breaker.state === 'OPEN') {
                 providerStatus = 'down';
@@ -411,17 +425,57 @@ export class VoiceErrorHandler {
         health.globalErrorRate = totalRequests > 0 ? totalErrors / totalRequests : 0;
 
         // Determine overall system status
-        const downProviders = Object.values(health.providers).filter(p => p.status === 'down').length;
-        const degradedProviders = Object.values(health.providers).filter(p => p.status === 'degraded').length;
+        const downProviders = Object.values(health.providers).filter(
+            (p) => p.status === 'down'
+        ).length;
+        const degradedProviders = Object.values(health.providers).filter(
+            (p) => p.status === 'degraded'
+        ).length;
 
         if (downProviders > Object.keys(health.providers).length / 2) {
             health.status = 'critical';
-        } else if (downProviders > 0 || degradedProviders > Object.keys(health.providers).length / 3) {
+        } else if (
+            downProviders > 0 ||
+            degradedProviders > Object.keys(health.providers).length / 3
+        ) {
             health.status = 'degraded';
         }
 
         return health;
     }
+}
+
+/**
+ * Redact sensitive credentials from an object before logging.
+ * Strips api_key / apiKey / Authorization-style fields (case-insensitive)
+ * recursively, returning a shallow-cloned, safe-to-log copy. Non-object
+ * values are returned unchanged.
+ * @param {*} input - Object (e.g. request body / headers) to sanitize
+ * @returns {*} Redacted copy
+ */
+export function redact(input) {
+    if (Array.isArray(input)) {
+        return input.map((item) => redact(item));
+    }
+
+    if (input === null || typeof input !== 'object') {
+        return input;
+    }
+
+    const SENSITIVE = /(api[-_]?key|authorization|x-api-key|secret|password|token)/i;
+    const result = {};
+
+    for (const [key, value] of Object.entries(input)) {
+        if (SENSITIVE.test(key)) {
+            result[key] = '[REDACTED]';
+        } else if (value && typeof value === 'object') {
+            result[key] = redact(value);
+        } else {
+            result[key] = value;
+        }
+    }
+
+    return result;
 }
 
 /**

--- a/test/analytics-tracker.test.js
+++ b/test/analytics-tracker.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AnalyticsTracker } from '../src/services/analytics-tracker.js';
+
+/**
+ * Unit tests for AnalyticsTracker.calculateCost across each pricing model.
+ * calculateCost is a pure function of the passed session object, so we build
+ * minimal session objects rather than running full operation lifecycles.
+ */
+describe('AnalyticsTracker.calculateCost', () => {
+    let tracker;
+
+    beforeEach(() => {
+        tracker = new AnalyticsTracker();
+        // Stop the periodic flush timer started by init() so tests stay isolated.
+        if (tracker.flushTimer) clearInterval(tracker.flushTimer);
+    });
+
+    afterEach(() => {
+        if (tracker.flushTimer) clearInterval(tracker.flushTimer);
+    });
+
+    const baseSession = (overrides = {}) => ({
+        provider: 'unknown',
+        operation: 'transcribe',
+        duration: 60000, // 1 minute
+        usage: { inputTokens: 0, outputTokens: 0, characters: 0, minutes: 0 },
+        metadata: {},
+        ...overrides
+    });
+
+    it('returns 0 for an unknown provider', () => {
+        const cost = tracker.calculateCost(baseSession({ provider: 'does-not-exist' }));
+        expect(cost).toBe(0);
+    });
+
+    it('computes openai-realtime cost from input/output tokens', () => {
+        const session = baseSession({
+            provider: 'openai-realtime',
+            operation: 'realtime',
+            duration: 60000,
+            usage: { inputTokens: 1_000_000, outputTokens: 1_000_000 }
+        });
+        // input: 1e6 tokens * 0.06 / 1e6 * 60 = 3.6
+        // output: 1e6 tokens * 0.24 / 1e6 * 60 = 14.4 => total 18.0
+        expect(tracker.calculateCost(session)).toBeCloseTo(18.0, 5);
+    });
+
+    it('uses streaming rate for deepgram realtime and pre-recorded otherwise', () => {
+        const streaming = tracker.calculateCost(
+            baseSession({ provider: 'deepgram', operation: 'realtime', duration: 60000 })
+        );
+        const preRecorded = tracker.calculateCost(
+            baseSession({ provider: 'deepgram', operation: 'transcribe', duration: 60000 })
+        );
+        expect(streaming).toBeCloseTo(0.0077, 5);
+        expect(preRecorded).toBeCloseTo(0.0043, 5);
+        expect(streaming).toBeGreaterThan(preRecorded);
+    });
+
+    it('applies the 0.1-minute floor for short per-minute operations', () => {
+        // 600ms = 0.01 min, but floor is 0.1 min.
+        const cost = tracker.calculateCost(
+            baseSession({ provider: 'deepgram', operation: 'transcribe', duration: 600 })
+        );
+        expect(cost).toBeCloseTo(0.1 * 0.0043, 5);
+    });
+
+    it('charges elevenlabs per character at the pro rate', () => {
+        const cost = tracker.calculateCost(
+            baseSession({
+                provider: 'elevenlabs',
+                operation: 'synthesize',
+                usage: { characters: 1000 }
+            })
+        );
+        // 1000 chars * 0.00024 = 0.24
+        expect(cost).toBeCloseTo(0.24, 5);
+    });
+
+    it('falls back to metadata.textLength for per-character providers when usage absent', () => {
+        const cost = tracker.calculateCost(
+            baseSession({
+                provider: 'amazon-polly',
+                operation: 'synthesize',
+                usage: {},
+                metadata: { textLength: 1_000_000 }
+            })
+        );
+        // 1e6 chars * 0.000004 = 4.0
+        expect(cost).toBeCloseTo(4.0, 5);
+    });
+
+    it('computes assemblyai per-hour cost with a 0.01-hour floor', () => {
+        const realtime = tracker.calculateCost(
+            baseSession({ provider: 'assemblyai', operation: 'realtime', duration: 3_600_000 })
+        );
+        const async = tracker.calculateCost(
+            baseSession({ provider: 'assemblyai', operation: 'transcribe', duration: 3_600_000 })
+        );
+        expect(realtime).toBeCloseTo(0.47, 5);
+        expect(async).toBeCloseTo(0.37, 5);
+    });
+});

--- a/test/config-manager-crypto.test.js
+++ b/test/config-manager-crypto.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ConfigManager } from '../src/config/config-manager.js';
+
+describe('ConfigManager crypto (createCipheriv migration)', () => {
+    let manager;
+
+    beforeEach(() => {
+        manager = new ConfigManager();
+        // Deterministic key so behavior is independent of the environment.
+        manager.encryptionKey = 'test-encryption-key-1234567890';
+    });
+
+    it('round-trips encrypt -> decrypt to the original plaintext', () => {
+        const plaintext = 'sk-test-1234567890';
+        const encrypted = manager.encrypt(plaintext);
+        expect(encrypted).not.toBe(plaintext);
+        expect(encrypted).toContain(':');
+        expect(manager.decrypt(encrypted)).toBe(plaintext);
+    });
+
+    it('produces different ciphertext for the same plaintext (random IV)', () => {
+        const a = manager.encrypt('sk-test-1234567890');
+        const b = manager.encrypt('sk-test-1234567890');
+        expect(a).not.toBe(b);
+        // Both still decrypt back to the same value.
+        expect(manager.decrypt(a)).toBe(manager.decrypt(b));
+    });
+
+    it('stores a real 16-byte IV in the iv:ciphertext format', () => {
+        const [ivHex] = manager.encrypt('sk-test-1234567890').split(':');
+        expect(ivHex).toHaveLength(32); // 16 bytes -> 32 hex chars
+    });
+
+    it('returns non-encrypted input unchanged (existing contract)', () => {
+        expect(manager.decrypt('plain-no-colon')).toBe('plain-no-colon');
+    });
+
+    it('does not throw on the current Node version', () => {
+        expect(() => manager.decrypt(manager.encrypt('hello'))).not.toThrow();
+    });
+
+    it('setProviderConfig -> getProviderConfig returns the original apiKey', async () => {
+        // Avoid touching disk: stub persistence.
+        manager.saveConfigurations = async () => {};
+        const userId = 'user-1';
+        await manager.setProviderConfig(userId, 'deepgram', {
+            apiKey: 'sk-roundtrip-apikey-123',
+            model: 'nova-2'
+        });
+        const config = manager.getProviderConfig(userId, 'deepgram');
+        expect(config.apiKey).toBe('sk-roundtrip-apikey-123');
+        expect(config.model).toBe('nova-2');
+    });
+});

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { VoiceErrorHandler, VoiceError, redact } from '../src/utils/error-handler.js';
+
+describe('VoiceErrorHandler.createVoiceError', () => {
+    let handler;
+
+    beforeEach(() => {
+        handler = new VoiceErrorHandler();
+    });
+
+    it('maps 401/unauthorized to AUTHENTICATION_ERROR and marks it non-retryable', () => {
+        const err = handler.createVoiceError(new Error('401 unauthorized'), 'deepgram', 0);
+        expect(err.type).toBe('AUTHENTICATION_ERROR');
+        expect(err.isRetryable).toBe(false);
+    });
+
+    it('maps 429/rate limit to RATE_LIMIT_ERROR (retryable)', () => {
+        const err = handler.createVoiceError(new Error('429 rate limit hit'), 'deepgram', 0);
+        expect(err.type).toBe('RATE_LIMIT_ERROR');
+        expect(err.isRetryable).toBe(true);
+    });
+
+    it('maps ECONNREFUSED/ENOTFOUND to NETWORK_ERROR', () => {
+        expect(handler.createVoiceError(new Error('ECONNREFUSED'), 'p', 0).type).toBe(
+            'NETWORK_ERROR'
+        );
+        expect(handler.createVoiceError(new Error('getaddrinfo ENOTFOUND'), 'p', 0).type).toBe(
+            'NETWORK_ERROR'
+        );
+    });
+
+    it('maps timeout messages to TIMEOUT', () => {
+        expect(handler.createVoiceError(new Error('Operation timeout'), 'p', 0).type).toBe(
+            'TIMEOUT'
+        );
+    });
+
+    it('returns an existing VoiceError unchanged', () => {
+        const original = new VoiceError('boom', 'CUSTOM');
+        expect(handler.createVoiceError(original, 'p', 0)).toBe(original);
+    });
+
+    it('defaults to UNKNOWN_ERROR for unrecognized messages', () => {
+        expect(handler.createVoiceError(new Error('weird stuff'), 'p', 0).type).toBe(
+            'UNKNOWN_ERROR'
+        );
+    });
+});
+
+describe('VoiceErrorHandler circuit breaker', () => {
+    it('opens after the failure threshold and becomes unavailable', () => {
+        const handler = new VoiceErrorHandler({ circuitBreakerThreshold: 3 });
+        const provider = 'deepgram';
+        const err = new VoiceError('fail', 'SERVER_ERROR');
+
+        expect(handler.isProviderAvailable(provider)).toBe(true);
+
+        for (let i = 0; i < 3; i++) {
+            handler.updateCircuitBreaker(provider, err);
+        }
+
+        const breaker = handler.circuitBreakers.get(provider);
+        expect(breaker.state).toBe('OPEN');
+        expect(handler.isProviderAvailable(provider)).toBe(false);
+    });
+
+    it('transitions to HALF_OPEN after the timeout elapses', () => {
+        vi.useFakeTimers();
+        try {
+            const handler = new VoiceErrorHandler({
+                circuitBreakerThreshold: 1,
+                circuitBreakerTimeout: 5000
+            });
+            const provider = 'deepgram';
+            handler.updateCircuitBreaker(provider, new VoiceError('fail', 'SERVER_ERROR'));
+            expect(handler.circuitBreakers.get(provider).state).toBe('OPEN');
+            expect(handler.isProviderAvailable(provider)).toBe(false);
+
+            vi.advanceTimersByTime(5001);
+
+            // The next availability check should flip OPEN -> HALF_OPEN and allow a try.
+            expect(handler.isProviderAvailable(provider)).toBe(true);
+            expect(handler.circuitBreakers.get(provider).state).toBe('HALF_OPEN');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('closes again after a success while HALF_OPEN', () => {
+        const handler = new VoiceErrorHandler({ circuitBreakerThreshold: 1 });
+        const provider = 'deepgram';
+        const breaker = handler.circuitBreakers.get(provider);
+        breaker.state = 'HALF_OPEN';
+
+        handler.recordSuccess(provider, 100);
+        expect(breaker.state).toBe('CLOSED');
+        expect(breaker.failures).toBe(0);
+    });
+});
+
+describe('redact', () => {
+    it('removes api_key and Authorization while keeping other fields', () => {
+        const out = redact({
+            provider: 'deepgram',
+            api_key: 'sk-secret',
+            apiKey: 'sk-secret2',
+            Authorization: 'Bearer xyz',
+            nested: { 'x-api-key': 'leak', keep: 'ok' }
+        });
+        expect(out.provider).toBe('deepgram');
+        expect(out.api_key).toBe('[REDACTED]');
+        expect(out.apiKey).toBe('[REDACTED]');
+        expect(out.Authorization).toBe('[REDACTED]');
+        expect(out.nested['x-api-key']).toBe('[REDACTED]');
+        expect(out.nested.keep).toBe('ok');
+    });
+
+    it('returns non-object values unchanged', () => {
+        expect(redact('hello')).toBe('hello');
+        expect(redact(42)).toBe(42);
+        expect(redact(null)).toBe(null);
+    });
+});

--- a/test/error-middleware.test.js
+++ b/test/error-middleware.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import {
+    notFoundHandler,
+    errorHandler,
+    statusForErrorType
+} from '../src/middleware/error-middleware.js';
+import { VoiceError } from '../src/utils/error-handler.js';
+
+function buildApp(routeSetup) {
+    const app = express();
+    app.use(express.json());
+    if (routeSetup) routeSetup(app);
+    app.use(notFoundHandler);
+    app.use(errorHandler);
+    return app;
+}
+
+describe('statusForErrorType', () => {
+    it('maps known VoiceError types to HTTP statuses', () => {
+        expect(statusForErrorType('AUTHENTICATION_ERROR')).toBe(401);
+        expect(statusForErrorType('AUTHORIZATION_ERROR')).toBe(403);
+        expect(statusForErrorType('RATE_LIMIT_ERROR')).toBe(429);
+        expect(statusForErrorType('SOMETHING_ELSE')).toBe(500);
+    });
+});
+
+describe('notFoundHandler', () => {
+    it('returns a JSON 404 envelope', async () => {
+        const app = buildApp();
+        const res = await request(app).get('/nope');
+        expect(res.status).toBe(404);
+        expect(res.body).toEqual({ error: { message: 'Not Found', type: 'not_found' } });
+    });
+});
+
+describe('errorHandler', () => {
+    it('maps a thrown VoiceError to its status and envelope', async () => {
+        const app = buildApp((a) => {
+            a.get('/boom', (req, res, next) => {
+                next(new VoiceError('bad key', 'AUTHENTICATION_ERROR'));
+            });
+        });
+        const res = await request(app).get('/boom');
+        expect(res.status).toBe(401);
+        expect(res.body.error.type).toBe('AUTHENTICATION_ERROR');
+        expect(res.body.error.message).toBe('bad key');
+    });
+
+    it('maps a generic Error to a 500 internal envelope', async () => {
+        const app = buildApp((a) => {
+            a.get('/oops', () => {
+                throw new Error('kaboom');
+            });
+        });
+        const res = await request(app).get('/oops');
+        expect(res.status).toBe(500);
+        expect(res.body.error.type).toBe('internal_error');
+    });
+});

--- a/test/voice-api-endpoints.test.js
+++ b/test/voice-api-endpoints.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { VoiceAPIEndpoints } from '../src/routes/voice-api-endpoints.js';
+import { notFoundHandler, errorHandler } from '../src/middleware/error-middleware.js';
+
+function buildApp() {
+    const app = express();
+    app.use(express.json());
+    // skipInit avoids file IO + background timers during tests.
+    new VoiceAPIEndpoints(app, { skipInit: true });
+    app.use(notFoundHandler);
+    app.use(errorHandler);
+    return app;
+}
+
+describe('Voice API endpoints', () => {
+    let app;
+
+    beforeAll(() => {
+        app = buildApp();
+    });
+
+    it('GET /v1/voice/providers returns a list with categories', async () => {
+        const res = await request(app).get('/v1/voice/providers');
+        expect(res.status).toBe(200);
+        expect(res.body.object).toBe('list');
+        expect(Array.isArray(res.body.data)).toBe(true);
+        expect(res.body.data.length).toBeGreaterThan(0);
+        expect(res.body.categories).toBeDefined();
+    });
+
+    it('GET /v1/voice/providers?type=stt filters the list', async () => {
+        const res = await request(app).get('/v1/voice/providers?type=stt');
+        expect(res.status).toBe(200);
+        for (const p of res.body.data) {
+            const matches = p.type === 'stt' || (p.capabilities || []).includes('stt');
+            expect(matches).toBe(true);
+        }
+    });
+
+    it('GET /v1/voice/models returns a model list', async () => {
+        const res = await request(app).get('/v1/voice/models');
+        expect(res.status).toBe(200);
+        expect(res.body.object).toBe('list');
+        expect(res.body.data[0]).toHaveProperty('id');
+        expect(res.body.data[0]).toHaveProperty('provider');
+    });
+
+    it('GET /v1/voice/providers/:provider 404s for an unknown provider', async () => {
+        const res = await request(app).get('/v1/voice/providers/does-not-exist');
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBeDefined();
+    });
+
+    it('GET /v1/voice/providers/:provider returns details for a known provider', async () => {
+        const res = await request(app).get('/v1/voice/providers/deepgram');
+        expect(res.status).toBe(200);
+        expect(res.body.id).toBe('deepgram');
+        expect(res.body.name).toBeDefined();
+    });
+
+    it('POST /v1/voice/transcribe 400s when provider/api_key missing', async () => {
+        const res = await request(app).post('/v1/voice/transcribe').send({});
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/required/i);
+    });
+
+    it('POST /v1/voice/transcribe 400s when audio is missing', async () => {
+        const res = await request(app)
+            .post('/v1/voice/transcribe')
+            .send({ provider: 'deepgram', api_key: 'token-123' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/audio/i);
+    });
+
+    it('POST /v1/voice/synthesize 400s when text is missing', async () => {
+        const res = await request(app)
+            .post('/v1/voice/synthesize')
+            .send({ provider: 'elevenlabs', api_key: 'token-123' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/required/i);
+    });
+
+    it('returns a JSON 404 envelope for unknown /v1/voice paths', async () => {
+        const res = await request(app).get('/v1/voice/does-not-exist');
+        expect(res.status).toBe(404);
+        expect(res.body).toEqual({ error: { message: 'Not Found', type: 'not_found' } });
+    });
+});

--- a/test/voice-router.test.js
+++ b/test/voice-router.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { VoiceRouter } from '../src/routes/voice-router.js';
+
+describe('VoiceRouter.listProviders', () => {
+    let router;
+
+    beforeEach(() => {
+        router = new VoiceRouter();
+    });
+
+    it('returns all providers when no type filter is given', () => {
+        const all = router.listProviders();
+        expect(Object.keys(all).length).toBeGreaterThan(0);
+        expect(all['openai-realtime']).toBeDefined();
+    });
+
+    it('filters providers by type', () => {
+        const stt = router.listProviders('stt');
+        for (const config of Object.values(stt)) {
+            const matches = config.type === 'stt' || config.capabilities.includes('stt');
+            expect(matches).toBe(true);
+        }
+        // A known TTS-only provider should not appear under stt.
+        expect(stt['elevenlabs']).toBeUndefined();
+    });
+});
+
+describe('VoiceRouter.validateProvider', () => {
+    let router;
+
+    beforeEach(() => {
+        router = new VoiceRouter();
+    });
+
+    it('rejects an unknown provider', () => {
+        const result = router.validateProvider('nope', 'key');
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/not found/i);
+    });
+
+    it('rejects when the API key is missing', () => {
+        const result = router.validateProvider('deepgram', '');
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/api key is required/i);
+    });
+
+    it('accepts a known provider with an API key', () => {
+        const result = router.validateProvider('deepgram', 'token-123');
+        expect(result.valid).toBe(true);
+    });
+});
+
+describe('VoiceRouter.routeRequest', () => {
+    let router;
+
+    beforeEach(() => {
+        router = new VoiceRouter();
+    });
+
+    it('throws for an unsupported provider', async () => {
+        await expect(router.routeRequest({ provider: 'unsupported', apiKey: 'k' })).rejects.toThrow(
+            /not supported/i
+        );
+    });
+
+    it('throws when no API key is supplied', async () => {
+        await expect(router.routeRequest({ provider: 'deepgram' })).rejects.toThrow(
+            /api key required/i
+        );
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['test/**/*.test.js'],
+        globals: true,
+        clearMocks: true,
+        restoreMocks: true
+    }
+});


### PR DESCRIPTION
## Summary

Implements three AI-suggested improvements end-to-end, plus quality tooling and a daily CI workflow. All changes are additive and focused; `npm test`, `npm run lint`, and `npm run format:check` all pass (44 tests).

## Features

### 1. Real automated test suite + tooling (Vitest + Supertest, ESLint, Prettier)
**Rationale:** `npm test` was only `node --check` (a syntax check) with zero unit/integration tests and no lint/format config. Lots of pure, high-risk logic was untested.
**Source:** Vitest + Supertest as the recommended 2026 stack for ESM Node/Express APIs (zero-config ESM, faster than Jest).
- `npm test` -> `vitest run`; added `lint`, `format`, `format:check`, `precommit` scripts.
- `eslint.config.js` (flat config), `.prettierrc.json`, `.prettierignore`, `vitest.config.js`.
- 44 tests across:
  - `AnalyticsTracker.calculateCost` — openai-realtime token math, deepgram streaming vs pre-recorded, elevenlabs per-character, amazon-polly metadata fallback, assemblyai per-hour, unknown-provider => 0, and the 0.1-minute floor.
  - `VoiceErrorHandler.createVoiceError` — 401->AUTHENTICATION_ERROR (non-retryable), 429->RATE_LIMIT_ERROR, ECONNREFUSED/ENOTFOUND->NETWORK_ERROR, timeout->TIMEOUT; circuit breaker opening after threshold, OPEN->HALF_OPEN after timeout, HALF_OPEN->CLOSED on success.
  - `VoiceRouter.listProviders(type)` filtering, `validateProvider` errors, `routeRequest` guards.
  - Supertest against the voice endpoints: `GET /v1/voice/providers` (object:list + categories), `GET /v1/voice/providers/:provider` 404, transcribe/synthesize 400 validation, and the JSON 404 envelope.
  - `redact()` unit tests.

### 2. Fix deprecated/insecure crypto (`src/config/config-manager.js`)
**Rationale:** `createCipher`/`createDecipher` were removed in Node 22 (would throw at runtime) and used insecure key derivation; the random IV was decorative and ignored.
**Source:** Node removed `createCipher`/`createDecipher` in v22; migration requires scrypt-derived 32-byte key + 16-byte stored IV.
- Migrated to `createCipheriv`/`createDecipheriv` (`aes-256-cbc`) with a `scryptSync`-derived 32-byte key and a real per-message random IV, preserving the on-disk `iv:ciphertext` format.
- Tests verify round-trip, IV randomness (different ciphertext for same plaintext), malformed input passthrough, no throw on current Node, and `setProviderConfig`->`getProviderConfig` apiKey round-trip.

### 3. Centralized Express error-handling + 404 middleware with redaction (`src/middleware/error-middleware.js`)
**Rationale:** Every handler repeated `try/catch -> res.status(500)`, there was no error/404 middleware, and api_key could leak into logs/responses.
**Source:** Express best practice of a centralized 4-arg error handler + catch-all 404, never logging secrets.
- `notFoundHandler` (JSON `{error:{message:'Not Found',type:'not_found'}}`) and 4-arg `errorHandler` mapping `VoiceError.type` -> status (AUTHENTICATION_ERROR->401, RATE_LIMIT_ERROR->429, else 500) returning `{error:{message,type}}`.
- `redact()` util strips api_key/Authorization/secret/token fields recursively before logging; wired into `server.setupExpress()` after all routes.

## Testing done
- `npm test` — 44 passing.
- `npm run lint` — 0 errors (also fixed a pre-existing duplicate `generateSessionId` and `no-case-declarations` errors).
- `npm run format:check` — clean.
- `node --check src/core/server.js` — passes; server auto-start guarded so it is importable in tests.

## Daily CI
`.github/workflows/daily-ci.yml` runs on push, pull_request, and a daily cron (`0 6 * * *`, 06:00 UTC) plus manual dispatch. Installs deps with `npm ci`, runs lint, prettier check, the test suite, and a syntax check on Node 20 and 22. Existing Claude review workflows are untouched. A `.githooks/pre-commit` (lint -> format -> test), wired via the `prepare` script, runs the same gates locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)